### PR TITLE
Update CDT version soft max + better info in tests #442

### DIFF
--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -15,7 +15,7 @@ docker-compose up -d
 
 # Run unit-tests
 sleep 10s
-docker run --network golos-tests_contracts-net -ti cyberway/golos.contracts:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/golos.contracts/unit_test && /opt/cyberway.contracts/unit_test -t "!cyber_system_tests/*"'
+docker run --network golos-tests_contracts-net -ti cyberway/golos.contracts:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/golos.contracts/unit_test -l message -r detailed && /opt/cyberway.contracts/unit_test -t "!cyber_system_tests/*"'
 result=$?
 
 docker-compose down

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(golos_dapp_contracts VERSION 0.1.0)
 
 set(EOSIO_CDT_VERSION_MIN "1.4")
-set(EOSIO_CDT_VERSION_SOFT_MAX "1.4")
+set(EOSIO_CDT_VERSION_SOFT_MAX "1.5")
 #set(EOSIO_CDT_VERSION_HARD_MAX "")
 
 find_package(eosio.cdt)

--- a/UnitTestsExternalProject.txt
+++ b/UnitTestsExternalProject.txt
@@ -3,7 +3,11 @@ find_package(Git REQUIRED)
 include(GNUInstallDirs)
 
 if(EOSIO_ROOT STREQUAL "" OR NOT EOSIO_ROOT)
-  set(EOSIO_ROOT "/opt/eosio")
+  if(APPLE)
+    set(EOSIO_ROOT "/usr/local/eosio")
+  else()
+    set(EOSIO_ROOT "/opt/eosio")
+  endif()
 endif()
 
 string(REPLACE ";" "|" TEST_FRAMEWORK_PATH "${CMAKE_FRAMEWORK_PATH}")

--- a/tests/golos_tester.cpp
+++ b/tests/golos_tester.cpp
@@ -187,6 +187,9 @@ vector<variant> golos_tester::get_all_chaindb_rows(name code, uint64_t scope, na
         auto v = _chaindb.value_at_cursor(cursor);
         all.push_back(v);
     }
+    if (!all.size()) {
+        BOOST_TEST_REQUIRE(!strict);
+    }
     return all;
 }
 

--- a/tests/golos_tester.hpp
+++ b/tests/golos_tester.hpp
@@ -50,10 +50,8 @@ protected:
 
 public:
     golos_tester(name code): tester(), _code(code), _chaindb(control->chaindb()) {
-        std::cout << "golos_tester()" << std::endl;
     }
     ~golos_tester() {
-        std::cout << "~golos_tester()" << std::endl;
     }
 
     void install_contract(account_name acc, const std::vector<uint8_t>& wasm, const std::vector<char>& abi, bool produce = true);


### PR DESCRIPTION
1. fix CDT version warnings when use 1.5
2. Remove debug logs on tester construct/destruct
3. Restore `strict` in `golos_tester::get_all_chaindb_rows`
4. Allow to show info and report when running tests in build-kite
5. Don't change `EOSIO_ROOT` on macos build