### PR TITLE
Remove `key` from witness struct of ctrl contract #516

### DIFF
--- a/golos.ctrl/abi/golos.ctrl.abi
+++ b/golos.ctrl/abi/golos.ctrl.abi
@@ -37,7 +37,6 @@
             "base": "",
             "fields": [
                 {"type": "name", "name": "witness"},
-                {"type": "public_key", "name": "key"},
                 {"type": "string", "name": "url"}
             ]
         }, {
@@ -45,6 +44,13 @@
             "base": "",
             "fields": [
                 {"type": "name",   "name": "witness"}
+            ]
+        }, {
+            "name": "votewitness",
+            "base": "",
+            "fields": [
+                {"type": "name", "name": "voter"},
+                {"type": "name", "name": "witness"}
             ]
         }, {
             "name": "unvotewitn",
@@ -61,25 +67,16 @@
                 {"type": "asset", "name": "diff"}
             ]
         }, {
-            "name": "votewitness",
-            "base": "",
-            "fields": [
-                {"type": "name", "name": "voter"},
-                {"type": "name", "name": "witness"},
-                {"type": "uint16", "name": "weight"}
-            ]
-        }, {
             "name": "witness_info",
             "base": "",
             "fields": [
                 {"type": "name", "name": "name"},
-                {"type": "public_key", "name": "key"},
                 {"type": "string", "name": "url"},
                 {"type": "bool", "name": "active"},
                 {"type": "uint64", "name": "total_weight"}
             ]
         }, {
-            "name": "witness_voter_s",
+            "name": "witness_voter",
             "base": "",
             "fields": [
                 {"type": "name", "name": "voter"},
@@ -139,7 +136,7 @@
                 {"type": "uint64", "name": "weight"}
             ]
         }, {
-            "name": "witnesses_auth",
+            "name": "msig_auths",
             "fields": [
                 {"type": "uint64", "name": "id"},
                 {"type": "name[]", "name": "witnesses"},
@@ -170,14 +167,14 @@
             "name": "unregwitness",
             "type": "unregwitness"
         }, {
+            "name": "votewitness",
+            "type": "votewitness"
+        }, {
             "name": "unvotewitn",
             "type": "unvotewitn"
         }, {
             "name": "changevest",
             "type": "changevest"
-        }, {
-            "name": "votewitness",
-            "type": "votewitness"
         }
     ],
     "tables": [
@@ -203,7 +200,7 @@
             }]
         }, {
             "name": "witnessvote",
-            "type": "witness_voter_s",
+            "type": "witness_voter",
             "indexes" : [{
                 "name": "primary",
                 "unique": true,
@@ -218,8 +215,8 @@
                 "orders": [{"field": "id", "order": "asc"}]
             }]
         }, {
-            "name": "witnessauth",
-            "type": "witnesses_auth",
+            "name": "msigauths",
+            "type": "msig_auths",
             "indexes" : [{
                 "name": "primary",
                 "unique": true,

--- a/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
+++ b/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
@@ -18,7 +18,6 @@ using share_type = int64_t;
 
 struct [[eosio::table]] witness_info {
     name name;
-    eosio::public_key key;
     std::string url;        // not sure it's should be in db (but can be useful to get witness info)
     bool active;            // can check key instead or even remove record
 
@@ -28,14 +27,14 @@ struct [[eosio::table]] witness_info {
         return name.value;
     }
     uint64_t weight_key() const {
-        return total_weight;     // TODO: resolve case where 2+ same weights exist (?extend key to 128bit)
+        return total_weight;
     }
 };
 using witness_weight_idx = indexed_by<"byweight"_n, const_mem_fun<witness_info, uint64_t, &witness_info::weight_key>>;
 using witness_tbl = eosio::multi_index<"witness"_n, witness_info, witness_weight_idx>;
 
 
-struct [[eosio::table]] witness_voter_s {
+struct [[eosio::table]] witness_voter {
     name voter;
     std::vector<name> witnesses;
 
@@ -43,7 +42,7 @@ struct [[eosio::table]] witness_voter_s {
         return voter.value;
     }
 };
-using witness_vote_tbl = eosio::multi_index<"witnessvote"_n, witness_voter_s>;
+using witness_vote_tbl = eosio::multi_index<"witnessvote"_n, witness_voter>;
 
 
 struct [[eosio::table]] bw_user {   // ?needed or simple names vector will be enough?
@@ -56,11 +55,11 @@ struct [[eosio::table]] bw_user {   // ?needed or simple names vector will be en
 };
 using bw_user_tbl = eosio::multi_index<"bwuser"_n, bw_user>;
 
-struct [[eosio::table]] msig_auth_singleton {
+struct [[eosio::table]] msig_auths {
     std::vector<name> witnesses;
     time_point_sec last_update;
 };
-using msig_auth_singleton_tbl = eosio::singleton<"witnessauth"_n, msig_auth_singleton>;
+using msig_auth_singleton = eosio::singleton<"msigauths"_n, msig_auths>;
 
 
 class control: public contract {
@@ -82,9 +81,9 @@ public:
         return itr != tbl.end() && itr->attached;
     }
 
-    [[eosio::action]] void regwitness(name witness, eosio::public_key key, std::string url);
+    [[eosio::action]] void regwitness(name witness, std::string url);
     [[eosio::action]] void unregwitness(name witness);
-    [[eosio::action]] void votewitness(name voter, name witness, uint16_t weight = 10000);
+    [[eosio::action]] void votewitness(name voter, name witness);
     [[eosio::action]] void unvotewitn(name voter, name witness);
 
     [[eosio::action]] void changevest(name who, asset diff);

--- a/golos.ctrl/src/golos.ctrl.cpp
+++ b/golos.ctrl/src/golos.ctrl.cpp
@@ -156,17 +156,15 @@ void control::detachacc(name user) {
     eosio_assert(exist, "user not found");
 }
 
-void control::regwitness(name witness, eosio::public_key key, string url) {
+void control::regwitness(name witness, string url) {
     assert_started();
     eosio_assert(url.length() <= config::witness_max_url_size, "url too long");
-    eosio_assert(key != eosio::public_key(), "public key should not be the default value");
     require_auth(witness);
 
     upsert_tbl<witness_tbl>(witness, [&](bool exists) {
         return [&,exists](witness_info& w) {
-            eosio_assert(!exists || w.key != key || w.url != url, "already updated in the same way");
+            eosio_assert(!exists || w.url != url || !w.active, "already updated in the same way");
             w.name = witness;
-            w.key = key;
             w.url = url;
             w.active = true;
         };
@@ -193,7 +191,7 @@ void control::unregwitness(name witness) {
 }
 
 // Note: if not weighted, it's possible to pass all witnesses in vector like in BP actions
-void control::votewitness(name voter, name witness, uint16_t weight/* = 10000*/) {
+void control::votewitness(name voter, name witness) {
     assert_started();
     require_auth(voter);
 
@@ -290,10 +288,10 @@ void control::update_witnesses_weights(vector<name> witnesses, share_type diff) 
 }
 
 void control::update_auths() {
-    msig_auth_singleton_tbl top_witnesses_tbl(_self, _self.value);
+    msig_auth_singleton tbl(_self, _self.value);
+    const auto& top_auths = tbl.get_or_default();
 
-    auto last_update = top_witnesses_tbl.get_or_default().last_update.utc_seconds;
-
+    auto last_update = top_auths.last_update.utc_seconds;
     if (last_update && props().update_auth_period.period + last_update > now())
         return;
 
@@ -302,19 +300,17 @@ void control::update_auths() {
         return it1.value < it2.value;
     });
 
-    const auto &old_top = top_witnesses_tbl.get_or_default().witnesses;
-
+    const auto& old_top = top_auths.witnesses;
     if (old_top.size() > 0 && old_top.size() == top.size()) {
-        bool result = std::equal(old_top.begin(), old_top.end(), top.begin(), [] (const auto& old_element, const auto& new_element) {
-            return old_element.value == new_element.value;
+        bool result = std::equal(old_top.begin(), old_top.end(), top.begin(), [](const auto& prev, const auto& cur) {
+            return prev.value == cur.value;
         });
-
-        if ( result )
+        if (result)
             return;
     }
 
     if (top.size())
-        top_witnesses_tbl.set({top, time_point_sec(now())}, _self);
+        tbl.set({top, time_point_sec(now())}, _self);
 
     auto max_witn = props().witnesses.max;
     if (top.size() < max_witn) {           // TODO: ?restrict only just after creation and allow later

--- a/golos.vesting/golos.vesting.abi
+++ b/golos.vesting/golos.vesting.abi
@@ -19,16 +19,6 @@
       ]
     },
     {
-      "name": "vesting_symbol",
-      "base": "",
-      "fields": [
-        {
-          "name": "vesting",
-          "type": "symbol"
-        }
-      ]
-    },
-    {
       "name": "user_balance",
       "base": "",
       "fields": [

--- a/golos.vesting/golos.vesting.cpp
+++ b/golos.vesting/golos.vesting.cpp
@@ -49,7 +49,7 @@ void vesting::on_transfer(name from, name to, asset quantity, std::string memo) 
     if(token::get_issuer(config::token_name, quantity.symbol.code()) == from && recipient == name())
         return;     // just increase token supply
 
-    tables::vesting_table table_vesting(_self, _self.value);
+    tables::vesting_table table_vesting(_self, _self.value);    // TODO: use symbol as scope
     auto vesting = table_vesting.find(quantity.symbol.code().raw());
     eosio_assert(vesting != table_vesting.end(), "Token not found");
 

--- a/scripts/golos-boot-sequence/golos-boot-sequence.py
+++ b/scripts/golos-boot-sequence/golos-boot-sequence.py
@@ -155,16 +155,15 @@ def buyVesting(account, amount):
     issueToken(account, amount)
     transfer(account, 'gls.vesting', amount)   # buy vesting
 
-def registerWitness(ctrl, witness, key):
+def registerWitness(ctrl, witness):
     retry(args.cleos + 'push action ' + ctrl + ' regwitness' + jsonArg({
         'witness': witness,
-        'key': key,
         'url': 'http://%s.witnesses.golos.io' % witness
     }) + '-p %s'%witness)
 
-def voteWitness(ctrl, voter, witness, weight):
+def voteWitness(ctrl, voter, witness):
     retry(args.cleos + ' push action ' + ctrl + ' votewitness ' +
-        jsonArg([voter, witness, weight]) + '-p %s'%voter)
+        jsonArg([voter, witness]) + '-p %s'%voter)
 
 def createPost(author, permlink, header, body, *, beneficiaries=[]):
     retry(args.cleos + 'push action gls.publish createmssg' +
@@ -324,8 +323,8 @@ def createWitnessAccounts():
         createAccount('cyber', a['name'], a['pub'])
         openVestingBalance(a['name'])
         buyVesting(a['name'], intToToken(10000000*10000))
-        registerWitness('gls.ctrl', a['name'], a['pub'])
-        voteWitness('gls.ctrl', a['name'], a['name'], 10000)
+        registerWitness('gls.ctrl', a['name'])
+        voteWitness('gls.ctrl', a['name'], a['name'])
 
 def initCommunity():
     retry(args.cleos + 'push action gls.publish setparams ' + jsonArg([[

--- a/scripts/posting_script/dbs.py
+++ b/scripts/posting_script/dbs.py
@@ -12,7 +12,7 @@ cyberway_db = client['_CYBERWAY_TEST_']
 
 def convert_hash(param):
     hashobj = hashlib.sha256(param.encode('utf-8')).hexdigest()
-    return Decimal128(Decimal(int(hashobj[:16], 16))) 
+    return Decimal128(Decimal(int(hashobj[:16], 16)))
 
 def printProgressBar (iteration, total, prefix = '', suffix = '', decimals = 1, length = 100, fill = '█'):
     percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))

--- a/scripts/testnet.py
+++ b/scripts/testnet.py
@@ -98,18 +98,17 @@ def buyVesting(account, amount):
     issueToken(account, amount)
     transfer(account, 'gls.vesting', amount)   # buy vesting
 
-def registerWitness(witness, key, url=None):
+def registerWitness(witness, url=None):
     if url == None:
         url = 'http://%s.witnesses.golos.io' % witness
     pushAction('gls.ctrl', 'regwitness', witness, {
         'domain': args.token,
         'witness': witness,
-        'key': key,
         'url': url
     })
 
-def voteWitness(voter, witness, weight):
-    pushAction('gls.ctrl', 'votewitness', voter, [voter, witness, weight])
+def voteWitness(voter, witness):
+    pushAction('gls.ctrl', 'votewitness', voter, [voter, witness])
 
 def createPost(author, permlink, category, header, body, *, beneficiaries=[]):
     pushAction('gls.publish', 'createmssg', author,

--- a/tests/golos.ctrl_test_api.hpp
+++ b/tests/golos.ctrl_test_api.hpp
@@ -57,10 +57,9 @@ struct golos_ctrl_api: base_contract_api {
         );
     }
 
-    action_result reg_witness(name witness, string key, string url) {
+    action_result reg_witness(name witness, string url) {
         return push(N(regwitness), witness, args()
             ("witness", witness)
-            ("key", key)    // TODO: remove
             ("url", url)
         );
     }
@@ -71,16 +70,17 @@ struct golos_ctrl_api: base_contract_api {
         );
     }
 
-    action_result vote_witness(name voter, name witness, uint16_t weight=10000) {
+    action_result vote_witness(name voter, name witness) {
         return push(N(votewitness), voter, args()
             ("voter", voter)
             ("witness", witness)
-            ("weight", weight));
+        );
     }
     action_result unvote_witness(name voter, name witness) {
         return push(N(unvotewitn), voter, args()
             ("voter", voter)
-            ("witness", witness));
+            ("witness", witness)
+        );
     }
 
     action_result change_vests(name who, asset diff) {
@@ -106,8 +106,8 @@ struct golos_ctrl_api: base_contract_api {
         return _tester->get_all_chaindb_rows(_code, _code, N(witness), false);
     }
 
-    variant get_top_witnesses() const {
-        return get_struct(_code, N(witnessauth), N(witnessauth), "witnesses_auth");
+    variant get_msig_auths() const {
+        return get_struct(_code, N(msigauths), N(msigauths), "msig_auths");
     }
 
     //// helpers

--- a/tests/golos.params_tests.cpp
+++ b/tests/golos.params_tests.cpp
@@ -79,10 +79,8 @@ public:
         ctrl.prepare_multisig(BLOG);
         produce_block();
 
-        const string _test_key = string(fc::crypto::config::public_key_legacy_prefix)
-            + "6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV";
         for (int i = 0; i < _n_w; i++) {
-            BOOST_CHECK_EQUAL(success(), ctrl.reg_witness(_w[i], _test_key, "localhost"));
+            BOOST_CHECK_EQUAL(success(), ctrl.reg_witness(_w[i], "localhost"));
         }
         produce_block();
 


### PR DESCRIPTION
+ remove `key` field from witness struct and `regwitness` action (outdated, not used)
+ remove `weight` argument from `votewitness` action (not used)
+ fix `regwitness` action to allow reactivate witness (deactivated with `unregwitness`) without requirement to change url
+ rename `witnessauth` table to `msig_auths`
+ reorder abi structs/action to be more consistent
+ remove unused struct from vesting abi
+ minor refactoring