### PR TITLE
Added the ability to comment on posts outside the payout window #521

### DIFF
--- a/golos.publication/golos.publication.abi
+++ b/golos.publication/golos.publication.abi
@@ -243,6 +243,10 @@
         "type": "mssgid"
       },
       {
+        "name": "parent_recid",
+        "type": "uint64"
+      },
+      {
         "name": "beneficiaries",
         "type": "beneficiary[]"
       },
@@ -697,6 +701,13 @@
     ]
   },
   {
+    "name": "create_event",
+    "base": "",
+    "fields": [
+        {"name": "record_id", "type": "uint64"}
+    ]
+  },
+  {
     "name": "post_event",
     "base": "",
     "fields": [
@@ -742,6 +753,7 @@
   "events": [
     {"name": "poolstate", "type": "pool_event"},
     {"name": "poolerase", "type": "uint64"},
+    {"name": "postcreate","type": "create_event"},
     {"name": "poststate", "type": "post_event"},
     {"name": "postclose", "type": "post_close"},
     {"name": "votestate", "type": "vote_event"}

--- a/golos.publication/golos.publication.hpp
+++ b/golos.publication/golos.publication.hpp
@@ -14,7 +14,7 @@ public:
     void set_rules(const funcparams& mainfunc, const funcparams& curationfunc, const funcparams& timepenalty,
         int64_t curatorsprop, int64_t maxtokenprop, symbol tokensymbol);
     void on_transfer(name from, name to, asset quantity, std::string memo);
-    void create_message(structures::mssgid message_id, structures::mssgid parent_id,
+    void create_message(structures::mssgid message_id, structures::mssgid parent_id, uint64_t parent_recid,
         std::vector<structures::beneficiary> beneficiaries, int64_t tokenprop, bool vestpayment,
         std::string headermssg, std::string bodymssg, std::string languagemssg, std::vector<structures::tag> tags,
         std::string jsonmetadata);
@@ -30,7 +30,6 @@ public:
 private:
     void close_message_timer(structures::mssgid message_id, uint64_t id, uint64_t delay_sec);
     void set_vote(name voter, const structures::mssgid &message_id, int16_t weight);
-    uint16_t notify_parent(bool increase, name parentacc, uint64_t parent_id);
     void fill_depleted_pool(tables::reward_pools& pools, asset quantity,
         tables::reward_pools::const_iterator excluded);
     auto get_pool(tables::reward_pools& pools, uint64_t time);

--- a/golos.publication/objects.hpp
+++ b/golos.publication/objects.hpp
@@ -12,10 +12,6 @@ namespace golos { namespace structures {
 
 using namespace eosio;
 
-struct accandvalue {
-    name account;
-    uint64_t value;
-};
 using counter_t = uint64_t;
 struct beneficiary {
     name account;
@@ -37,8 +33,21 @@ struct mssgid {
     std::string permlink;
     uint64_t ref_block_num;
 
+    bool operator==(const mssgid& value) const {
+        return author == value.author &&
+               permlink == value.permlink &&
+               ref_block_num == value.ref_block_num;
+    }
+
     EOSLIB_SERIALIZE(mssgid, (author)(permlink)(ref_block_num))
 };
+
+struct archive_info_v1 {
+    mssgid id;
+    uint16_t level;
+};
+
+using archive_record = std::variant<archive_info_v1>;
 
 struct messagestate {
     base_t netshares = 0;
@@ -139,6 +148,10 @@ struct rewardpool {
 
     uint64_t primary_key() const { return created; }
     EOSLIB_SERIALIZE(rewardpool, (created)(rules)(state))
+};
+
+struct create_event {
+    uint64_t record_id;
 };
 
 struct post_event {

--- a/tests/golos.posting_test_api.hpp
+++ b/tests/golos.posting_test_api.hpp
@@ -43,6 +43,7 @@ struct golos_posting_api: base_contract_api {
     action_result create_msg(
         mssgid message_id,
         mssgid parent_id = {N(), "parentprmlnk", 0},
+        uint64_t parent_recid = 0,
         std::vector<beneficiary> beneficiaries = {},
         int64_t token_prop = 5000,
         bool vest_payment = false,
@@ -55,6 +56,7 @@ struct golos_posting_api: base_contract_api {
         return push(N(createmssg), message_id.author, args()
             ("message_id", message_id)
             ("parent_id", parent_id)
+            ("parent_recid", parent_recid)
             ("beneficiaries", beneficiaries)
             ("tokenprop", token_prop)
             ("vestpayment", vest_payment)

--- a/tests/golos.publication_rewards_tests.cpp
+++ b/tests/golos.publication_rewards_tests.cpp
@@ -435,7 +435,7 @@ public:
     ) {
         auto ref_block_num = control->head_block_header().block_num();
         const auto current_time = control->head_block_time().sec_since_epoch();
-        auto ret = post.create_msg(message_id, parent_message_id, beneficiaries, tokenprop, vestpayment);
+        auto ret = post.create_msg(message_id, parent_message_id, 0, beneficiaries, tokenprop, vestpayment);
 //        message_key key{author, permlink};
 
         auto reward_weight = 0.0;

--- a/tests/golos.referral_tests.cpp
+++ b/tests/golos.referral_tests.cpp
@@ -245,9 +245,9 @@ BOOST_FIXTURE_TEST_CASE(create_referral_message_tests, golos_referral_tester) tr
     BOOST_CHECK_EQUAL( post_sania["beneficiaries"][uint8_t(0)].as<beneficiary>().account, N(issuer) );
 
     BOOST_CHECK_EQUAL(success(), referral.create_referral(N(issuer), N(pasha), 5000, current_time + expire, token.make_asset(50)));
-    BOOST_CHECK_EQUAL(err.limit_percents, post.create_msg({N(pasha), "permlink", ref_block_num}, {N(), "parentprmlnk", 0}, { beneficiary{N(tania), 7000} }));
-    BOOST_CHECK_EQUAL(err.referrer_benif, post.create_msg({N(pasha), "permlink", ref_block_num}, {N(), "parentprmlnk", 0}, { beneficiary{N(issuer), 2000} }));
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(pasha), "permlink", ref_block_num}, {N(), "parentprmlnk", 0}, { beneficiary{N(tania), 2000} }));
+    BOOST_CHECK_EQUAL(err.limit_percents, post.create_msg({N(pasha), "permlink", ref_block_num}, {N(), "parentprmlnk", 0}, 0, { beneficiary{N(tania), 7000} }));
+    BOOST_CHECK_EQUAL(err.referrer_benif, post.create_msg({N(pasha), "permlink", ref_block_num}, {N(), "parentprmlnk", 0}, 0, { beneficiary{N(issuer), 2000} }));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(pasha), "permlink", ref_block_num}, {N(), "parentprmlnk", 0}, 0, { beneficiary{N(tania), 2000} }));
 
     auto post_pasha = post.get_message({N(pasha), "permlink", ref_block_num});
     BOOST_CHECK_EQUAL (post_pasha["beneficiaries"].size(), 2);


### PR DESCRIPTION
Resolves #521
Added a new argument `parent_recid` to the create message action. This argument contains the ID of the archive record in which the parent post was created.
Changed the search logic of the parent post:
1. parent post is searched in the voting window
2. if it is not found and the archive record identifier is specified, then it is checked that the record matches the specified parent post
3. If the identifier is not specified or the record is missing, an error is generated about the absence of the parent post.
Independent voting windows for post comments have been implemented.