### PR TITLE
Add script to create genesis data #594

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -48,10 +48,12 @@ COPY --from=builder /golos.contracts/cyberway.contracts/tests/test_contracts /op
 COPY --from=builder /golos.contracts/cyberway.contracts/scripts/bios-boot-sequence /opt/cyberway.contracts/scripts/bios-boot-sequence
 COPY --from=builder /golos.contracts/scripts /opt/golos.contracts/scripts
 COPY --from=builder /golos.contracts/scripts/boot-sequence.py /opt/golos.contracts/scripts/boot-sequence.py
+COPY --from=builder /golos.contracts/genesis /opt/golos.contracts/genesis
 
 COPY --from=builder /usr/local/lib/libbson-1.0.so.0.0.0 /usr/local/lib/
 COPY --from=cyberway /opt/cyberway/bin/cleos /opt/cyberway/bin/cleos
 COPY --from=cyberway /opt/cyberway/bin/keosd /opt/cyberway/bin/keosd
+COPY --from=cyberway /opt/cyberway/bin/create-genesis /opt/cyberway/bin/create-genesis
 
 RUN ldconfig && ln -s ../cyberway.contracts /opt/golos.contracts/cyberway.contracts
 

--- a/genesis/genesis-info.json.tmpl
+++ b/genesis/genesis-info.json.tmpl
@@ -1,0 +1,61 @@
+{
+    "state_file": "golos.dat",
+    "genesis_json": "genesis.json",
+    "accounts": [
+#        {"name": "cyber",         "owner_key": "INITIAL",   "active_key": "INITIAL",
+#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.bios/cyber.bios.abi", "hash":""},
+#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.bios/cyber.bios.wasm", "hash":""}
+#        },
+#        {"name": "cyber.domain",  "owner_key": "INITIAL",   "active_key": "INITIAL",
+#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.domain/cyber.domain.abi", "hash":""},
+#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.domain/cyber.domain.wasm", "hash":""}
+#        },
+        {"name": "cyber.token",   "owner_key": "INITIAL",   "active_key": "INITIAL",
+            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.token/cyber.token.abi", "hash":""},
+            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.token/cyber.token.wasm", "hash":""}
+        },
+#        {"name": "cyber.msig",   "owner_key": "INITIAL",   "active_key": "INITIAL",
+#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.msig/cyber.msig.abi", "hash":""},
+#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.msig/cyber.msig.wasm", "hash":""}
+#        },
+#        {"name": "cyber.govern",   "owner_key": "INITIAL",   "active_key": "INITIAL",
+#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.govern/cyber.govern.abi", "hash":""},
+#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.govern/cyber.govern.wasm", "hash":""}
+#        },
+#        {"name": "cyber.stake",   "owner_key": "INITIAL",   "active_key": "INITIAL",
+#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.stake/cyber.stake.abi", "hash":""},
+#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.stake/cyber.stake.wasm", "hash":""}
+#        },
+
+        {"name": "gls.issuer",    "owner_key": "INITIAL",   "active_key": "INITIAL"},
+        {"name": "gls.ctrl",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+            "abi": {"path": "$GOLOS_CONTRACTS/golos.ctrl/golos.ctrl.abi", "hash":""},
+            "code": {"path": "$GOLOS_CONTRACTS/golos.ctrl/golos.ctrl.wasm", "hash":""}
+        },
+        {"name": "gls.emit",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+            "abi": {"path": "$GOLOS_CONTRACTS/golos.emit/golos.emit.abi", "hash":""},
+            "code": {"path": "$GOLOS_CONTRACTS/golos.emit/golos.emit.wasm", "hash":""}
+        },
+        {"name": "gls.vesting",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+            "abi": {"path": "$GOLOS_CONTRACTS/golos.vesting/golos.vesting.abi", "hash":""},
+            "code": {"path": "$GOLOS_CONTRACTS/golos.vesting/golos.vesting.wasm", "hash":""}
+        },
+        {"name": "gls.publish",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+            "abi": {"path": "$GOLOS_CONTRACTS/golos.publication/golos.publication.abi", "hash":""},
+            "code": {"path": "$GOLOS_CONTRACTS/golos.publication/golos.publication.wasm", "hash":""}
+        },
+        {"name": "gls.social",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+            "abi": {"path": "$GOLOS_CONTRACTS/golos.social/golos.social.abi", "hash":""},
+            "code": {"path": "$GOLOS_CONTRACTS/golos.social/golos.social.wasm", "hash":""}
+        },
+        {"name": "gls.charge",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+            "abi": {"path": "$GOLOS_CONTRACTS/golos.charge/golos.charge.abi", "hash":""},
+            "code": {"path": "$GOLOS_CONTRACTS/golos.charge/golos.charge.wasm", "hash":""}
+        },
+        {"name": "gls.referral",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+            "abi": {"path": "$GOLOS_CONTRACTS/golos.referral/golos.referral.abi", "hash":""},
+            "code": {"path": "$GOLOS_CONTRACTS/golos.referral/golos.referral.wasm", "hash":""}
+        },
+        {"name": "gls.worker",        "owner_key": "INITIAL",   "active_key": "INITIAL"}
+    ]
+}

--- a/genesis/genesis.json.tmpl
+++ b/genesis/genesis.json.tmpl
@@ -1,0 +1,25 @@
+{
+  "initial_timestamp": "${INITIAL_TIMESTAMP}",
+  "initial_key": "GLS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV",
+  "initial_configuration": {
+    "max_block_net_usage": 1048576,
+    "target_block_net_usage_pct": 1000,
+    "max_transaction_net_usage": 524288,
+    "base_per_transaction_net_usage": 12,
+    "net_usage_leeway": 500,
+    "context_free_discount_net_usage_num": 20,
+    "context_free_discount_net_usage_den": 100,
+    "max_block_cpu_usage": 2500000,
+    "target_block_cpu_usage_pct": 1000,
+    "max_transaction_cpu_usage": 1800000,
+    "min_transaction_cpu_usage": 100,
+    "max_transaction_lifetime": 3600,
+    "deferred_trx_expiration_window": 600,
+    "max_transaction_delay": 3888000,
+    "max_inline_action_size": 4096,
+    "max_inline_action_depth": 4,
+    "max_authority_depth": 6
+  },
+  "initial_chain_id": "0000000000000000000000000000000000000000000000000000000000000000",
+  "genesis_data_hash": "${GENESIS_DATA_HASH}"
+}

--- a/scripts/create-genesis.sh
+++ b/scripts/create-genesis.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+
+: ${TAG:="latest"}
+: ${DEST:="genesis-data-temp"}
+: ${GOLOS_STATE:="golos.dat"}
+
+INITIAL_TIMESTAMP=$(date +"%FT%T.%3N" -d12)
+GOLOS_IMAGE=cyberway/golos.contracts:$TAG
+GOLOS=golos.genesis
+
+docker kill $GOLOS || true
+docker rm $GOLOS || true
+
+echo "Create directory $DEST"
+[ -d $DEST ] || mkdir $DEST
+
+echo "Info about images $GOLOS_IMAGE:"
+docker image ls $GOLOS_IMAGE | tail -n +2
+
+docker run --name $GOLOS cyberway/golos.contracts:$TAG sleep 300 &
+sleep 1
+docker ps
+docker cp $GOLOS_STATE $GOLOS:/golos.dat
+docker cp $GOLOS_STATE.map $GOLOS:/golos.dat.map
+
+docker exec $GOLOS bash -c \
+    'ls -l / /opt/cyberway/bin/ /opt/golos.contracts /opt/golos.contracts/genesis &&
+     sed "s|\${INITIAL_TIMESTAMP}|'$INITIAL_TIMESTAMP'|" /opt/golos.contracts/genesis/genesis.json.tmpl | tee genesis.json && \
+     sed "s|\$CYBERWAY_CONTRACTS|$CYBERWAY_CONTRACTS|;s|\$GOLOS_CONTRACTS|$GOLOS_CONTRACTS|; /^#/d" /opt/golos.contracts/genesis/genesis-info.json.tmpl | tee genesis-info.json && \
+     /opt/cyberway/bin/create-genesis -g genesis-info.json -o genesis.dat && \
+     sed -i "s|\${GENESIS_DATA_HASH}|$(sha256sum genesis.dat | cut -f1 -d" ")|" genesis.json && cat genesis.json'
+
+docker cp $GOLOS:genesis.dat $DEST/genesis.dat
+docker cp $GOLOS:genesis.json $DEST/genesis.json
+
+docker kill $GOLOS && docker rm $GOLOS


### PR DESCRIPTION
Resolves #594
Save create-genesis utility, create-genesis.sh scripts and templates for genesis-info.json, genesis.json in golos.contracts container.
This scripts deploy Docker-container and creates genesis data for nodeos.