### PR TITLE
Make posting contract percents `int` where applicable #619

### DIFF
--- a/common/calclib/fixed_point_utils.h
+++ b/common/calclib/fixed_point_utils.h
@@ -16,8 +16,14 @@ namespace fixed_point_utils {
 
 using fixp_t = sg14::fixed_point<base_t, -fixed_point_fractional_digits>;
 using wdfp_t = sg14::fixed_point<wide_t, -fixed_point_fractional_digits>;
+
+// elastic with same number of fractional digits as fixp_t has
 using elap_t = sg14::elastic_fixed_point<fixp_t::integer_digits, fixp_t::fractional_digits, base_t>;
+
+// elastic with all (except 1) digits fractional (for values less than or equal to 1)
 using elaf_t = sg14::fixed_point<sg14::elastic_integer<std::numeric_limits<base_t>::digits, base_t>, -(std::numeric_limits<base_t>::digits - 1)>;
+
+// "integer" elastic with no fractional digits
 using elai_t = sg14::fixed_point<sg14::elastic_integer<std::numeric_limits<base_t>::digits, base_t>, 0>;
 
 constexpr fixp_t FP(base_t a) { return fixp_t::from_data(a); };

--- a/docs/ru-RU/golos.publication_contract.md
+++ b/docs/ru-RU/golos.publication_contract.md
@@ -41,8 +41,7 @@ void setrules(
     const funcparams&	mainfunc,
     const funcparams& 	curationfunc,
     const funcparams&	timepenalty,
-    int64_t 		    curatorsprop,
-    int64_t 		    maxtokenprop,
+    uint16_t 		    maxtokenprop,
     symbol 		        tokensymbol
 );
 ```
@@ -51,8 +50,7 @@ void setrules(
 `mainfunc` —  функция, вычисляющая суммарное значение вознаграждения для автора и кураторов поста в соответствии с установленным алгоритмом (например, линейным алгоритмом или алгоритмом квадратного корня). Используемый в функции алгоритм выбирается делегатами голосованием. Функция содержит два параметра: математическое выражение (непосредственно алгоритм), по которому вычисляется сумма вознаграждения, и максимально допустимое значение аргумента для функции. При установке значений параметров для setrules выполняется их проверка на корректность (в том числе на монотонность и неотрицательность);  
 `curationfunc` —  функция, вычисляющая значение вознаграждения для каждого из кураторов в соответствии с установленным алгоритмом (аналогично вычислению для `mainfunc`);  
 `timepenalty` —  функция, вычисляющая вес голоса с учетом времени голосования и длительности штрафного окна;  
-`curatorsprop` — выделяемая доля всем кураторам от суммарного значения вознаграждения;  
-`maxtokenprop` —  максимально возможное значение вознаграждения (сумма токенов и вестингов), которое может получить автор. Этот параметр устанавливается делегатами голосованием;  
+`maxtokenprop` —  максимально возможное значение вознаграждения (сумма токенов и вестингов), которое может получить автор. Этот параметр устанавливается делегатами голосованием. Целое число в сотых долях процента (от 0 до 10000 = 0%—100%);  
 `tokensymbol` —  тип токена (в рамках приложения Голос предусматривается хождение только токенов Голоса).  
 
 Правом на запуск операции-действия `setrules` обладает делегат приложения. Для запуска операции-действия `setrules` требуется наличие в транзакции подписи смарт-контракта `golos.publication` (multisig-аккаунта).  
@@ -67,13 +65,14 @@ void createmssg(
     name 		    parentacc,
     std::string 	parentprmlnk,
     std::vector<structures::beneficiary> beneficiaries,
-    int64_t 	    tokenprop,
+    uint16_t 	    tokenprop,
     bool 		    vestpayment,
     std::string 	headermssg,
     std::string 	bodymssg,
     std::string l	anguagemssg,
     std::vector<std::string> tags,
-    std::string 	jsonmetadata
+    std::string 	jsonmetadata,
+    optional<uint16_t> curators_prcnt
 );
 ```
 
@@ -89,7 +88,8 @@ void createmssg(
 `bodymssg` — тело сообщения;  
 `languagemssg` — язык сообщения;  
 `tags` — тэг, который присваивается сообщению;  
-`jsonmetadata` — метаданные в формате JSON.  
+`jsonmetadata` — метаданные в формате JSON;  
+`curators_prcnt` — доля кураторского вознаграждения. Ограничивается диапазоном заданным в параметре `curators_prcnt_param`. Необязательный параметр, значение по умолчанию = `curators_prcnt_param.min_curators_prcnt`.
 
 Параметры `parentacc`и `parentprmlnk` идентифицируют родительское сообщение, на которое создается ответ с использованием `createmssg` в виде сообщения.  
 
@@ -106,7 +106,7 @@ void updatemssg(
     name 		account,
     std::string 	permlink,
     std::string 	headermssg,
-    std::string 	bodymssg, 
+    std::string 	bodymssg,
     std::string 	languagemssg,
     std::vector<std::string> tags,
     std::string 	jsonmetadata

--- a/golos.charge/golos.charge.cpp
+++ b/golos.charge/golos.charge.cpp
@@ -133,7 +133,7 @@ void charge::send_charge_event(name user, const balance& state) {
 template<typename Lambda>
 void charge::consume_and_notify(name user, symbol_code token_code, uint8_t charge_id, int64_t price_arg, int64_t id, name code, name action_name, int64_t cutoff, name issuer, Lambda &&compare) {
     auto charge = consume_charge(issuer, user, token_code, charge_id, price_arg);
-    auto new_val = from_fixp(FP(charge.data()));
+    auto new_val = from_fixp(charge);
 
     if (compare(new_val, cutoff)) {
         action(

--- a/golos.publication/golos.publication.abi
+++ b/golos.publication/golos.publication.abi
@@ -16,6 +16,12 @@
     },{
       "new_type_name": "counter_t",
       "type": "uint64"
+    },{
+      "new_type_name": "percent_t",
+      "type": "uint16"
+    },{
+      "new_type_name": "signed_percent_t",
+      "type": "int16"
     }
   ],
   "variants": [{
@@ -122,8 +128,8 @@
         "type": "name"
       },
       {
-        "name": "deductprcnt",
-        "type": "base_t"
+        "name": "weight",
+        "type": "percent_t"
       }
     ]
   },
@@ -141,7 +147,7 @@
       },
       {
         "name": "interest_rate",
-        "type": "uint16"
+        "type": "percent_t"
       },
       {
         "name": "payout_strategy",
@@ -197,7 +203,7 @@
       },
       {
         "name": "tokenprop",
-        "type": "base_t"
+        "type": "percent_t"
       },
       {
         "name": "beneficiaries",
@@ -205,7 +211,7 @@
       },
       {
         "name": "rewardweight",
-        "type": "base_t"
+        "type": "percent_t"
       },
       {
         "name": "state",
@@ -213,7 +219,7 @@
       },
       {
         "name": "childcount",
-        "type": "uint64"
+        "type": "uint32"
       },
       {
         "name": "level",
@@ -221,7 +227,7 @@
       },
       {
         "name": "curators_prcnt",
-        "type": "base_t"
+        "type": "percent_t"
       }
     ]
   },
@@ -247,7 +253,7 @@
       },
       {
         "name": "tokenprop",
-        "type": "int64"
+        "type": "percent_t"
       },
       {
         "name": "vestpayment",
@@ -333,7 +339,7 @@
       },
       {
         "name": "weight",
-        "type": "uint16"
+        "type": "percent_t"
       }
     ]
   },
@@ -369,7 +375,7 @@
       },
       {
         "name": "weight",
-        "type": "int16"
+        "type": "signed_percent_t"
       },
       {
         "name": "time",
@@ -377,7 +383,7 @@
       },
       {
         "name": "count",
-        "type": "int64"
+        "type": "uint8"
       },
       {
         "name": "delegators",
@@ -425,7 +431,7 @@
         },
         {
             "name": "maxtokenprop",
-            "type": "base_t"
+            "type": "percent_t"
         }
     ]
   },
@@ -561,7 +567,7 @@
         },
         {
             "name": "maxtokenprop",
-            "type": "int64"
+            "type": "percent_t"
         },
         {
             "name": "tokensymbol",
@@ -639,11 +645,11 @@
     "fields": [
       {
         "name": "min_curators_prcnt",
-        "type": "uint16"
+        "type": "percent_t"
       },
       {
         "name": "max_curators_prcnt",
-        "type": "uint16"
+        "type": "percent_t"
       }
     ]
   },
@@ -719,7 +725,7 @@
         },
         {
             "name": "curators_prcnt",
-            "type": "uint16"
+            "type": "percent_t"
         }
     ]
   },
@@ -767,7 +773,7 @@
         {"name": "voter", "type": "name"},
         {"name": "author", "type": "name"},
         {"name": "permlink", "type": "string"},
-        {"name": "weight", "type": "int16"},
+        {"name": "weight", "type": "signed_percent_t"},
         {"name": "curatorsw", "type": "base_t"},
         {"name": "rshares", "type": "base_t"}
     ]
@@ -787,7 +793,7 @@
     "base": "",
     "fields": [
         {"name": "message_id", "type": "mssgid"},
-        {"name": "rewardweight", "type": "base_t"}
+        {"name": "rewardweight", "type": "percent_t"}
     ]
   }
   ],

--- a/golos.publication/golos.publication.cpp
+++ b/golos.publication/golos.publication.cpp
@@ -87,35 +87,48 @@ struct posting_params_setter: set_params_visitor<posting_state> {
     }
 };
 
-void publication::create_message(structures::mssgid message_id,
-                              structures::mssgid parent_id,
-                              uint64_t parent_recid,
-                              std::vector<structures::beneficiary> beneficiaries,
-                            //actually, beneficiaries[i].prop _here_ should be interpreted as (share * _100percent)
-                            //but not as a raw data for elaf_t, may be it's better to use another type (with uint16_t field for prop).
-                              int64_t tokenprop, bool vestpayment,
-                              std::string headermssg,
-                              std::string bodymssg, std::string languagemssg,
-                              std::vector<std::string> tags,
-                              std::string jsonmetadata,
-                              std::optional<uint16_t> curators_prcnt = std::nullopt) {
+// cached to prevent unneeded db access
+const posting_state& publication::params() {
+    static const auto cfg = posting_params_singleton(_self, _self.value).get();
+    return cfg;
+}
+
+void publication::create_message(
+    structures::mssgid message_id,
+    structures::mssgid parent_id,
+    uint64_t parent_recid,
+    std::vector<structures::beneficiary> beneficiaries,
+    uint16_t tokenprop,
+    bool vestpayment,
+    std::string headermssg,
+    std::string bodymssg,
+    std::string languagemssg,
+    std::vector<std::string> tags,
+    std::string jsonmetadata,
+    std::optional<uint16_t> curators_prcnt = std::nullopt
+) {
     require_auth(message_id.author);
 
     int ref_block_num = message_id.ref_block_num % 65536;
     eosio_assert((tapos_block_num()<ref_block_num?65536:0)+tapos_block_num()-ref_block_num < 2*60*60/3, "ref_block_num mismatch");
 
     eosio_assert(message_id.permlink.length() && message_id.permlink.length() < config::max_length, "Permlink length is empty or more than 256.");
-    eosio_assert(check_permlink_correctness(message_id.permlink), "Permlink contains wrong symbol.");
+    eosio_assert(validate_permlink(message_id.permlink), "Permlink contains wrong symbol.");
     eosio_assert(headermssg.length() < config::max_length, "Title length is more than 256.");
     eosio_assert(bodymssg.length(), "Body is empty.");
+    validate_percent(tokenprop, "tokenprop");
 
-    posting_params_singleton cfg(_self, _self.value);
-    const auto &cashout_window_param = cfg.get().cashout_window_param;
-    const auto &max_beneficiaries_param = cfg.get().max_beneficiaries_param;
-    const auto &max_comment_depth_param = cfg.get().max_comment_depth_param;
-    const auto &social_acc_param = cfg.get().social_acc_param;
-    const auto &referral_acc_param = cfg.get().referral_acc_param;
-    const auto &curators_prcnt_param = cfg.get().curators_prcnt_param;
+    const auto& cashout_window_param = params().cashout_window_param;
+    const auto& max_beneficiaries_param = params().max_beneficiaries_param;
+    const auto& max_comment_depth_param = params().max_comment_depth_param;
+    const auto& social_acc_param = params().social_acc_param;
+    const auto& referral_acc_param = params().referral_acc_param;
+    const auto& curators_prcnt_param = params().curators_prcnt_param;
+    if (curators_prcnt) {
+        curators_prcnt_param.validate_value(*curators_prcnt);
+    } else {
+        curators_prcnt = curators_prcnt_param.min_curators_prcnt;
+    }
 
     if (parent_id.author) {
         if (social_acc_param.account) {
@@ -139,44 +152,38 @@ void publication::create_message(structures::mssgid message_id,
     uint64_t message_pk = message_table.available_primary_key();
     if (message_pk == 0)
         message_pk = 1;
-    if(!parent_id.author)
+    if (!parent_id.author)
         use_postbw_charge(lims, issuer, message_id.author, token_code, message_pk);
 
-    std::map<name, int64_t> benefic_map;
-    int64_t prop_sum = 0;
+    std::map<name, uint16_t> benefic_map;
+    uint32_t weights_sum = 0;
     for (auto& ben : beneficiaries) {
+        validate_percent_not0(ben.weight, "beneficiary.weight");            // TODO: tests #617
+        eosio::check(benefic_map.count(ben.account) == 0, "beneficiaries contain several entries for one account");
         check_account(ben.account, pool->state.funds.symbol);
-        eosio_assert(0 < ben.deductprcnt && ben.deductprcnt <= config::_100percent, "publication::create_message: wrong ben.prop value");
-        prop_sum += ben.deductprcnt;
-        eosio_assert(prop_sum <= config::_100percent, "publication::create_message: prop_sum > 100%");
-        benefic_map[ben.account] += ben.deductprcnt; //several entries for one user? ok.
+        weights_sum += ben.weight;
+        validate_percent_le(weights_sum, "weights_sum of beneficiaries");   // TODO: tests #617
+        benefic_map[ben.account] = ben.weight;
     }
 
     if (referral_acc_param.account != name()) {
-        auto obj_referral = golos::referral::account_referrer( referral_acc_param.account, message_id.author );
-        if ( !obj_referral.is_empty() ) {
-            auto& referrer = obj_referral.referrer;
-            const auto& itr = std::find_if( beneficiaries.begin(), beneficiaries.end(),
-                                            [&referrer] (const structures::beneficiary& benef) {
-                return benef.account == referrer;
-            }
-            );
-
-            eosio_assert( itr == beneficiaries.end(), "Comment already has referrer as a referrer-beneficiary." );
-
-            prop_sum += obj_referral.percent;
-            eosio_assert(prop_sum <= config::_100percent, "publication::create_message: prop_sum > 100%");
-            benefic_map[obj_referral.referrer] += obj_referral.percent;
+        auto obj_referral = golos::referral::account_referrer(referral_acc_param.account, message_id.author);
+        if (!obj_referral.is_empty()) {
+            auto referrer = obj_referral.referrer;
+            eosio::check(benefic_map.count(referrer) == 0, "Comment already has referrer as a referrer-beneficiary.");
+            weights_sum += obj_referral.percent;
+            validate_percent_le(weights_sum, "weights_sum + referral percent"); // TODO: tests #617
+            benefic_map[referrer] = obj_referral.percent;
         }
     }
 
-        //reusing a vector
+    //reusing a vector
     beneficiaries.reserve(benefic_map.size());
     beneficiaries.clear();
-    for(auto & ben : benefic_map)
+    for (const auto& ben : benefic_map)
         beneficiaries.emplace_back(structures::beneficiary{
             .account = ben.first,
-            .deductprcnt = static_cast<base_t>(get_limit_prop(ben.second).data())
+            .weight = ben.second
         });
 
     eosio_assert((benefic_map.size() <= max_beneficiaries_param.max_beneficiaries), "publication::create_message: benafic_map.size() > MAX_BENEFICIARIES");
@@ -217,6 +224,7 @@ void publication::create_message(structures::mssgid message_id,
         }
     }
     eosio_assert(level <= max_comment_depth_param.max_comment_depth, "publication::create_message: level > MAX_COMMENT_DEPTH");
+    eosio::check(tokenprop <= pool->rules.maxtokenprop, "tokenprop must not be greater than pool.rules.maxtokenprop");
 
     auto mssg_itr = message_table.emplace(message_id.author, [&]( auto &item ) {
         item.id = message_pk;
@@ -225,12 +233,12 @@ void publication::create_message(structures::mssgid message_id,
         item.date = cur_time;
         item.parentacc = parent_id.author;
         item.parent_id = parent_pk;
-        item.tokenprop = static_cast<base_t>(std::min(get_limit_prop(tokenprop), ELF(pool->rules.maxtokenprop)).data()),
+        item.tokenprop = tokenprop,
         item.beneficiaries = beneficiaries;
-        item.rewardweight = static_cast<base_t>(elaf_t(1).data()); //we will get actual value from charge on post closing
+        item.rewardweight = config::_100percent;    // can be corrected later in calcrwrdwt
         item.childcount = 0;
         item.level = level;
-        item.curators_prcnt = get_checked_curators_prcnt(curators_prcnt);
+        item.curators_prcnt = *curators_prcnt;
     });
 
     structures::archive_info_v1 info{message_id,level};
@@ -415,7 +423,9 @@ void publication::close_message(structures::mssgid message_id) {
             auto denom = total_rsharesfn;
             narrow_down(numer, denom);
 
-            payout = int_cast(ELF(mssg_itr->rewardweight) * elai_t(elai_t(state.funds.amount) * static_cast<elaf_t>(elap_t(numer) / elap_t(denom))));
+            elaf_t reward_weight(elai_t(mssg_itr->rewardweight) / elai_t(config::_100percent));
+            payout = int_cast(
+                reward_weight * elai_t(elai_t(state.funds.amount) * elaf_t(elap_t(numer) / elap_t(denom))));
             state.funds.amount -= payout;
             eosio_assert(state.funds.amount >= 0, "LOGIC ERROR! publication::payrewards: state.funds < 0");
         }
@@ -430,7 +440,8 @@ void publication::close_message(structures::mssgid message_id) {
         state.rsharesfn = new_rsharesfn.data();
     }
 
-    auto curation_payout = int_cast(ELF(mssg_itr->curators_prcnt) * elai_t(payout));
+    elaf_t percent(elai_t(mssg_itr->curators_prcnt) / elai_t(config::_100percent));
+    auto curation_payout = int_cast(percent * elai_t(payout));
 
     eosio_assert((curation_payout <= payout) && (curation_payout >= 0), "publication::payrewards: wrong curation_payout");
     auto unclaimed_rewards = pay_curators(message_id.author, mssg_itr->id, curation_payout, FP(mssg_itr->state.sumcuratorsw), state.funds.symbol, get_memo("curators", message_id));
@@ -440,16 +451,18 @@ void publication::close_message(structures::mssgid message_id) {
     state.funds.amount += unclaimed_rewards;
     payout -= curation_payout;
 
+    const elap_t el_payout(elai_t(payout) / elai_t(config::_100percent));   // pre-divide
     int64_t ben_payout_sum = 0;
-    for(auto& ben : mssg_itr->beneficiaries) {
-        auto ben_payout = int_cast(elai_t(payout) * ELF(ben.deductprcnt));
+    for (auto& ben: mssg_itr->beneficiaries) {
+        auto ben_payout = int_cast(el_payout * elai_t(ben.weight));
         eosio_assert((0 <= ben_payout) && (ben_payout <= payout - ben_payout_sum), "LOGIC ERROR! publication::payrewards: wrong ben_payout value");
         payto(ben.account, eosio::asset(ben_payout, state.funds.symbol), static_cast<enum_t>(payment_t::VESTING), get_memo("benefeciary", message_id));
         ben_payout_sum += ben_payout;
     }
     payout -= ben_payout_sum;
 
-    auto token_payout = int_cast(elai_t(payout) * ELF(mssg_itr->tokenprop));
+    elaf_t token_prop(elai_t(mssg_itr->tokenprop) / elai_t(config::_100percent));
+    auto token_payout = int_cast(elai_t(payout) * token_prop);
     eosio_assert(payout >= token_payout, "publication::payrewards: wrong token_payout value");
     payto(message_id.author, eosio::asset(token_payout, state.funds.symbol), static_cast<enum_t>(payment_t::TOKEN), get_memo("author", message_id));
     payto(message_id.author, eosio::asset(payout - token_payout, state.funds.symbol), static_cast<enum_t>(payment_t::VESTING), get_memo("author", message_id));
@@ -493,16 +506,14 @@ void publication::close_message_timer(structures::mssgid message_id, uint64_t id
 }
 
 void publication::check_upvote_time(uint64_t cur_time, uint64_t mssg_date) {
-    posting_params_singleton cfg(_self, _self.value);
-    const auto &cashout_window_param = cfg.get().cashout_window_param;
-
+    const auto& cashout_window_param = params().cashout_window_param;
     eosio_assert((cur_time <= mssg_date + ((cashout_window_param.window - cashout_window_param.upvote_lockout) * seconds(1).count())) ||
                  (cur_time > mssg_date + (cashout_window_param.window * seconds(1).count())),
                  "You can't upvote, because publication will be closed soon.");
 }
 
 fixp_t publication::calc_available_rshares(name voter, int16_t weight, uint64_t cur_time, const structures::rewardpool& pool) {
-    elaf_t abs_w = get_limit_prop(abs(weight));
+    elaf_t abs_w(elai_t(abs(weight)) / elai_t(config::_100percent));
     tables::limit_table lims(_self, _self.value);
     auto token_code = pool.state.funds.symbol.code();
     int64_t eff_vesting = golos::vesting::get_account_effective_vesting(config::vesting_name, voter, token_code).amount;
@@ -520,9 +531,8 @@ void publication::set_vote(name voter, const structures::mssgid& message_id, int
         return set_and_run(machine, mainfunc_code, {netshares}, {{fixp_t(0), mainfunc_maxarg}}).data();
     };
 
-    posting_params_singleton cfg(_self, _self.value);
-    const auto &max_vote_changes_param = cfg.get().max_vote_changes_param;
-    const auto &social_acc_param = cfg.get().social_acc_param;
+    const auto& max_vote_changes_param = params().max_vote_changes_param;
+    const auto& social_acc_param = params().social_acc_param;
 
     tables::message_table message_table(_self, message_id.author.value);
     auto message_index = message_table.get_index<"bypermlink"_n>();
@@ -555,16 +565,16 @@ void publication::set_vote(name voter, const structures::mssgid& message_id, int
             item.state.rsharesfn = (WP(item.state.rsharesfn) + wdfp_t(rsharesfn_delta)).data();
             send_poolstate_event(item);
         });
-        
+
         message_index.modify(mssg_itr, name(), [&]( auto &item ) {
             item.state.netshares = new_mssg_rshares.data();
             item.state.sumcuratorsw = (FP(item.state.sumcuratorsw) - FP(vote_itr->curatorsw)).data();
             send_poststate_event(
-                message_id.author, 
-                item, 
+                message_id.author,
+                item,
                 get_calc_sharesfn(
-                    pool->rules.mainfunc.code, 
-                    FP(new_mssg_rshares.data()), 
+                    pool->rules.mainfunc.code,
+                    FP(new_mssg_rshares.data()),
                     FP(pool->rules.mainfunc.maxarg)
                 )
             );
@@ -602,7 +612,7 @@ void publication::set_vote(name voter, const structures::mssgid& message_id, int
          send_poolstate_event(item);
     });
     eosio_assert(WP(pool->state.rsharesfn) >= 0, "pool state rsharesfn overflow");
-    
+
     auto sumcuratorsw_delta = get_delta(machine, FP(mssg_itr->state.voteshares), FP(msg_new_state.voteshares), pool->rules.curationfunc);
     msg_new_state.sumcuratorsw = (FP(mssg_itr->state.sumcuratorsw) + sumcuratorsw_delta).data();
     message_index.modify(mssg_itr, _self, [&](auto &item) {
@@ -611,7 +621,7 @@ void publication::set_vote(name voter, const structures::mssgid& message_id, int
             message_id.author,
             item,
             get_calc_sharesfn(
-                pool->rules.mainfunc.code, 
+                pool->rules.mainfunc.code,
                 FP(msg_new_state.netshares),
                 FP(pool->rules.mainfunc.maxarg)
             )
@@ -715,7 +725,9 @@ void publication::set_limit(std::string act_str, symbol_code token_code, uint8_t
 }
 
 void publication::set_rules(const funcparams& mainfunc, const funcparams& curationfunc, const funcparams& timepenalty,
-    int64_t maxtokenprop, eosio::symbol tokensymbol) {
+    uint16_t maxtokenprop, eosio::symbol tokensymbol
+) {
+    validate_percent(maxtokenprop, "maxtokenprop");
     //TODO: machine's constants
     using namespace tables;
     using namespace structures;
@@ -743,8 +755,7 @@ void publication::set_rules(const funcparams& mainfunc, const funcparams& curati
     newrules.mainfunc     = load_func(mainfunc, "reward func", pa, machine, true);
     newrules.curationfunc = load_func(curationfunc, "curation func", pa, machine, true);
     newrules.timepenalty  = load_func(timepenalty, "time penalty func", pa, machine, true);
-
-    newrules.maxtokenprop = static_cast<base_t>(get_limit_prop(maxtokenprop).data());
+    newrules.maxtokenprop = maxtokenprop;
 
     pools.emplace(_self, [&](auto &item) {
         item.created = created;
@@ -777,7 +788,7 @@ void publication::send_votestate_event(name voter, const structures::voteinfo& v
     eosio::event(_self, "votestate"_n, data).send();
 }
 
-void publication::send_rewardweight_event(structures::mssgid message_id, base_t weight) {
+void publication::send_rewardweight_event(structures::mssgid message_id, uint16_t weight) {
     structures::reward_weight_event data{message_id, weight};
     eosio::event(_self, "rewardweight"_n, data).send();
 }
@@ -834,7 +845,7 @@ int64_t publication::pay_delegators(int64_t claim, name voter,
     return dlg_payout_sum;
 }
 
-bool publication::check_permlink_correctness(std::string permlink) {
+bool publication::validate_permlink(std::string permlink) {
     for (auto symbol : permlink) {
         if ((symbol >= '0' && symbol <= '9') ||
             (symbol >= 'a' && symbol <= 'z') ||
@@ -853,43 +864,32 @@ std::string publication::get_memo(const std::string &type, const structures::mss
                                                   + std::to_string(message_id.ref_block_num));
 }
 
-base_t publication::get_checked_curators_prcnt(std::optional<uint16_t> curators_prcnt) {
-    posting_params_singleton cfg(_self, _self.value);
-    const auto &curators_prcnt_param = cfg.get().curators_prcnt_param;
-
-    if (curators_prcnt.has_value()) {
-        eosio_assert(curators_prcnt.value() >= curators_prcnt_param.min_curators_prcnt,
-                     "Curators percent is less than min curators percent.");
-        eosio_assert(curators_prcnt.value() <= curators_prcnt_param.max_curators_prcnt,
-                     "Curators percent is greater than max curators percent.");
-            return static_cast<base_t>(get_limit_prop(static_cast<int64_t>(curators_prcnt.value())).data());
-    }
-    return static_cast<base_t>(get_limit_prop(static_cast<int64_t>(curators_prcnt_param.min_curators_prcnt)).data());
-}
-
 void publication::set_curators_prcnt(structures::mssgid message_id, uint16_t curators_prcnt) {
     require_auth(message_id.author);
+    const auto& param = params().curators_prcnt_param;
+    param.validate_value(curators_prcnt);
+
     tables::message_table message_table(_self, message_id.author.value);
     auto message_index = message_table.get_index<"bypermlink"_n>();
     auto message_itr = message_index.find({message_id.permlink, message_id.ref_block_num});
     eosio_assert(message_itr != message_index.end(), "Message doesn't exist.");
+    eosio_assert(message_itr->state.voteshares == 0, "Curators percent can be changed only before voting.");
+    eosio::check(message_itr->curators_prcnt != curators_prcnt, "Same curators percent value is already set."); // TODO: tests #617
 
-    eosio_assert(message_itr->state.voteshares == 0,
-            "Curators percent can be changed only before voting.");
-
-    message_index.modify(message_itr, name(), [&]( auto &item ) {
-            item.curators_prcnt = get_checked_curators_prcnt(curators_prcnt);
-        });
+    message_index.modify(message_itr, name(), [&](auto& item) {
+        item.curators_prcnt = curators_prcnt;
+    });
 }
 
-void publication::calcrwrdwt(name account, int64_t mssg_id, base_t post_charge) {
+void publication::calcrwrdwt(name account, int64_t mssg_id, int64_t post_charge) {
     require_auth(_self);
     tables::limit_table lims(_self, _self.value);
     auto bw_lim_itr = lims.find(structures::limitparams::POSTBW);
     eosio_assert(bw_lim_itr != lims.end(), "publication::calc_reward_weight: limit parameters not set");
     if (post_charge > bw_lim_itr->cutoff) {
-        auto weight = static_cast<elaf_t>(elai_t(bw_lim_itr->cutoff) / elai_t(post_charge));
-        auto reward_weight = static_cast<base_t>(weight.data()); 
+        elaf_t weight(elai_t(bw_lim_itr->cutoff) / elai_t(post_charge));
+        auto reward_weight = int_cast(elai_t(config::_100percent) * weight);
+        validate_percent(reward_weight, "calculated reward weight");        // should never fail in normal conditions
 
         tables::message_table message_table(_self, account.value);
         auto message_index = message_table.get_index<"primary"_n>();
@@ -899,7 +899,8 @@ void publication::calcrwrdwt(name account, int64_t mssg_id, base_t post_charge) 
             item.rewardweight = reward_weight;
         });
 
-        send_rewardweight_event(structures::mssgid{account, message_itr->permlink, message_itr->ref_block_num}, int_cast(elai_t(config::_100percent) * ELF(reward_weight)));
+        structures::mssgid msg_id{account, message_itr->permlink, message_itr->ref_block_num};
+        send_rewardweight_event(msg_id, reward_weight);
     }
 }
 

--- a/golos.publication/golos.publication.cpp
+++ b/golos.publication/golos.publication.cpp
@@ -8,6 +8,7 @@
 #include <common/upsert.hpp>
 #include "utils.hpp"
 #include "objects.hpp"
+#include <cyberway.contracts/common/util.hpp>
 
 namespace golos {
 
@@ -462,10 +463,9 @@ void publication::close_message(structures::mssgid message_id) {
     state.funds.amount += unclaimed_rewards;
     payout -= curation_payout;
 
-    const elap_t el_payout(elai_t(payout) / elai_t(config::_100percent));   // pre-divide
     int64_t ben_payout_sum = 0;
     for (auto& ben: mssg_itr->beneficiaries) {
-        auto ben_payout = int_cast(el_payout * elai_t(ben.weight));
+        auto ben_payout = cyber::safe_pct(payout, ben.weight);
         eosio_assert((0 <= ben_payout) && (ben_payout <= payout - ben_payout_sum), "LOGIC ERROR! publication::payrewards: wrong ben_payout value");
         payto(ben.account, eosio::asset(ben_payout, state.funds.symbol), static_cast<enum_t>(payment_t::VESTING), get_memo("benefeciary", message_id));
         ben_payout_sum += ben_payout;

--- a/golos.publication/golos.publication.hpp
+++ b/golos.publication/golos.publication.hpp
@@ -9,13 +9,13 @@ using namespace eosio;
 class publication : public contract {
 public:
     using contract::contract;
-    
+
     void set_limit(std::string act, symbol_code token_code, uint8_t charge_id, int64_t price, int64_t cutoff, int64_t vesting_price, int64_t min_vesting);
     void set_rules(const funcparams& mainfunc, const funcparams& curationfunc, const funcparams& timepenalty,
-        int64_t maxtokenprop, symbol tokensymbol);
+        uint16_t maxtokenprop, symbol tokensymbol);
     void on_transfer(name from, name to, asset quantity, std::string memo = "");
     void create_message(structures::mssgid message_id, structures::mssgid parent_id, uint64_t parent_recid,
-        std::vector<structures::beneficiary> beneficiaries, int64_t tokenprop, bool vestpayment,
+        std::vector<structures::beneficiary> beneficiaries, uint16_t tokenprop, bool vestpayment,
         std::string headermssg, std::string bodymssg, std::string languagemssg, std::vector<std::string> tags,
         std::string jsonmetadata, std::optional<uint16_t> curators_prcnt);
     void update_message(structures::mssgid message_id, std::string headermssg, std::string bodymssg,
@@ -28,8 +28,10 @@ public:
     void set_params(std::vector<posting_params> params);
     void reblog(name rebloger, structures::mssgid message_id);
     void set_curators_prcnt(structures::mssgid message_id, uint16_t curators_prcnt);
-    void calcrwrdwt(name account, int64_t mssg_id, base_t post_charge);
+    void calcrwrdwt(name account, int64_t mssg_id, int64_t post_charge);
+
 private:
+    const posting_state& params();
     void close_message_timer(structures::mssgid message_id, uint64_t id, uint64_t delay_sec);
     void set_vote(name voter, const structures::mssgid &message_id, int16_t weight);
     void fill_depleted_pool(tables::reward_pools& pools, asset quantity,
@@ -38,8 +40,8 @@ private:
     int64_t pay_curators(name author, uint64_t msgid, int64_t max_rewards, fixp_t weights_sum,
                          symbol tokensymbol, std::string memo = "");
     void payto(name user, asset quantity, enum_t mode, std::string memo = "");
-    void check_account(name user, symbol tokensymbol);
-    int64_t pay_delegators(int64_t claim, name voter, 
+    static void check_account(name user, symbol tokensymbol);
+    int64_t pay_delegators(int64_t claim, name voter,
             eosio::symbol tokensymbol, std::vector<structures::delegate_voter> delegate_list);
     base_t get_checked_curators_prcnt(std::optional<uint16_t> curators_prcnt);
 
@@ -47,20 +49,20 @@ private:
     void send_poolerase_event(const structures::rewardpool& pool);
     void send_poststate_event(name author, const structures::message& post, base_t sharesfn);
     void send_votestate_event(name voter, const structures::voteinfo& vote, name author, const structures::message& post);
-    void send_rewardweight_event(structures::mssgid message_id, base_t weight);
+    void send_rewardweight_event(structures::mssgid message_id, uint16_t weight);
 
     static structures::funcinfo load_func(const funcparams& params, const std::string& name,
         const atmsp::parser<fixp_t>& pa, atmsp::machine<fixp_t>& machine, bool inc);
     static fixp_t get_delta(atmsp::machine<fixp_t>& machine, fixp_t old_val, fixp_t new_val,
         const structures::funcinfo& func);
-        
+
     void use_charge(tables::limit_table& lims, structures::limitparams::act_t act, name issuer,
                         name account, int64_t eff_vesting, symbol_code token_code, bool vestpayment, elaf_t weight = elaf_t(1));
     void use_postbw_charge(tables::limit_table& lims, name issuer, name account, symbol_code token_code, int64_t mssg_id);
 
     fixp_t calc_available_rshares(name voter, int16_t weight, uint64_t cur_time, const structures::rewardpool& pool);
     void check_upvote_time(uint64_t cur_time, uint64_t mssg_date);
-    bool check_permlink_correctness(std::string permlink);
+    static bool validate_permlink(std::string permlink);
 
     std::string get_memo(const std::string &type, const structures::mssgid &message_id);
 };

--- a/golos.publication/objects.hpp
+++ b/golos.publication/objects.hpp
@@ -15,7 +15,7 @@ using namespace eosio;
 using counter_t = uint64_t;
 struct beneficiary {
     name account;
-    int64_t deductprcnt; //elaf_t
+    uint16_t weight;    // percent
 };
 
 struct mssgid {
@@ -56,18 +56,18 @@ struct message {
     uint64_t date;
     name parentacc;
     uint64_t parent_id;
-    base_t tokenprop; //elaf_t
+    uint16_t tokenprop;     // percent
     std::vector<structures::beneficiary> beneficiaries;
-    base_t rewardweight;//elaf_t
+    uint16_t rewardweight;  // percent
     messagestate state;
-    uint64_t childcount;
+    uint32_t childcount;
     uint16_t level;
-    base_t curators_prcnt;
+    uint16_t curators_prcnt;
 
     uint64_t primary_key() const {
         return id;
     }
-    
+
     std::tuple<std::string, uint64_t> secondary_key() const {
         return {permlink, ref_block_num};
     }
@@ -90,7 +90,7 @@ struct voteinfo {
     name voter;
     int16_t weight;
     uint64_t time;
-    int64_t count;
+    uint8_t count;
     std::vector<delegate_voter> delegators;
     base_t curatorsw;
     base_t rshares;
@@ -113,7 +113,7 @@ struct rewardrules {
     funcinfo mainfunc;
     funcinfo curationfunc;
     funcinfo timepenalty;
-    base_t maxtokenprop; //elaf_t
+    uint16_t maxtokenprop;  // percent
     //uint64_t cashout_time; //TODO:
 };
 
@@ -178,7 +178,7 @@ struct pool_event {
 
 struct reward_weight_event {
     mssgid message_id;
-    base_t rewardweight;
+    uint16_t rewardweight;
 };
 
 struct limitparams {
@@ -211,7 +211,7 @@ using message_table = multi_index<N(message), structures::message, id_index, per
 
 using vote_id_index = indexed_by<N(id), const_mem_fun<structures::voteinfo, uint64_t, &structures::voteinfo::primary_key>>;
 using vote_messageid_index = indexed_by<N(messageid), const_mem_fun<structures::voteinfo, uint64_t, &structures::voteinfo::by_message>>;
-using vote_group_index = indexed_by<N(byvoter), eosio::composite_key<structures::voteinfo, 
+using vote_group_index = indexed_by<N(byvoter), eosio::composite_key<structures::voteinfo,
       eosio::member<structures::voteinfo, uint64_t, &structures::voteinfo::message_id>,
       eosio::member<structures::voteinfo, name, &structures::voteinfo::voter>>>;
 using vote_table = multi_index<N(vote), structures::voteinfo, vote_id_index, vote_messageid_index, vote_group_index>;

--- a/golos.publication/parameters.hpp
+++ b/golos.publication/parameters.hpp
@@ -31,7 +31,7 @@ namespace golos {
 
     struct st_max_comment_depth : parameter {
         uint16_t max_comment_depth;
-        
+
         void validate() const override {
             eosio_assert(max_comment_depth > 0, "Max comment depth must be greater than 0.");
         }
@@ -48,7 +48,7 @@ namespace golos {
         }
     };
     using social_acc_prm = param_wrapper<st_social_acc, 1>;
-    
+
     struct st_referral_acc : parameter {
         name account;
 
@@ -59,7 +59,7 @@ namespace golos {
         }
     };
     using referral_acc_prm = param_wrapper<st_referral_acc, 1>;
-    
+
     struct st_curators_prcnt : parameter {
         uint16_t min_curators_prcnt;
         uint16_t max_curators_prcnt;
@@ -71,11 +71,15 @@ namespace golos {
                     "Min curators percent must be less than max curators percent or equal.");
             eosio_assert(max_curators_prcnt <= config::_100percent, "Max curators percent must be less than 100 or equal.");
         }
+        void validate_value(uint16_t x) const {
+            eosio::check(x >= min_curators_prcnt, "Curators percent is less than min curators percent.");
+            eosio::check(x <= max_curators_prcnt, "Curators percent is greater than max curators percent.");
+        }
     };
     using curators_prcnt_prm = param_wrapper<st_curators_prcnt, 2>;
 
 
-    using posting_params = std::variant<max_vote_changes_prm, cashout_window_prm, max_beneficiaries_prm, 
+    using posting_params = std::variant<max_vote_changes_prm, cashout_window_prm, max_beneficiaries_prm,
           max_comment_depth_prm, social_acc_prm, referral_acc_prm, curators_prcnt_prm>;
 
     struct [[eosio::table]] posting_state {

--- a/golos.publication/utils.hpp
+++ b/golos.publication/utils.hpp
@@ -25,15 +25,20 @@ fixp_t add_cut(fixp_t lhs, fixp_t rhs) {
     return fp_cast<fixp_t>(elap_t(lhs) + elap_t(rhs), false);
 }
 
-elaf_t get_limit_prop(int64_t arg) {
-    eosio_assert(arg >= 0, "get_limit_prop: arg < 0");
-    const int64_t p100 = config::_100percent;
-    return elaf_t(elai_t(std::min(arg, p100)) / elai_t(p100));
-}
-
 fixp_t get_prop(int64_t arg) {
     return fp_cast<fixp_t>(elai_t(arg) / elai_t(config::_100percent));
 }
+
+void validate_percent(uint32_t percent, std::string arg_name = "percent") {
+    eosio::check(0 <= percent && percent <= config::_100percent, arg_name + " must be between 0% and 100% (0-10000)");
+}
+void validate_percent_not0(uint32_t percent, std::string arg_name = "percent") {
+    eosio::check(0 < percent && percent <= config::_100percent, arg_name + " must be between 0.01% and 100% (1-10000)");
+}
+void validate_percent_le(uint32_t percent, std::string arg_name = "percent") {
+    eosio::check(percent <= config::_100percent, arg_name + " must not be greater than 100% (10000)");
+}
+
 
 void check_positive_monotonic(atmsp::machine<fixp_t>& machine, fixp_t max_arg, const std::string& name, bool inc) {
     fixp_t prev_res = machine.run({max_arg});

--- a/tests/golos.posting_test_api.hpp
+++ b/tests/golos.posting_test_api.hpp
@@ -16,7 +16,7 @@ struct golos_posting_api: base_contract_api {
         const funcparams& main_fn,
         const funcparams& curation_fn,
         const funcparams& time_penalty,
-        int64_t max_token_prop) {
+        uint16_t max_token_prop) {
         return push(N(setrules), _code, args()
             ("mainfunc", fn_to_mvo(main_fn))
             ("curationfunc", fn_to_mvo(curation_fn))
@@ -25,7 +25,7 @@ struct golos_posting_api: base_contract_api {
             ("tokensymbol", _symbol)
         );
     }
-    
+
     action_result set_limit(std::string act, uint8_t charge_id = 0, int64_t price = -1, int64_t cutoff = 0, int64_t vesting_price = 0, int64_t min_vesting = 0) {
         return push(N(setlimit), _code, args()
             ("act", act)
@@ -43,14 +43,14 @@ struct golos_posting_api: base_contract_api {
         mssgid parent_id = {N(), "parentprmlnk", 0},
         uint64_t parent_recid = 0,
         std::vector<beneficiary> beneficiaries = {},
-        int64_t token_prop = 5000,
+        uint16_t token_prop = 5000,
         bool vest_payment = false,
         std::string title = "headermssg",
         std::string body = "bodymssg",
         std::string language = "languagemssg",
         std::vector<std::string> tags = {"tag"},
         std::string json_metadata = "jsonmetadata",
-        optional<uint16_t> curators_prcnt = optional<uint16_t>() 
+        optional<uint16_t> curators_prcnt = optional<uint16_t>()
     ) {
         return push(N(createmssg), message_id.author, args()
             ("message_id", message_id)
@@ -122,7 +122,7 @@ struct golos_posting_api: base_contract_api {
         return push(N(setparams), _code, args()
             ("params", json_str_to_obj(json_params)));
     }
-    
+
 
     action_result init_default_params() {
         auto vote_changes = get_str_vote_changes(max_vote_changes);
@@ -133,10 +133,10 @@ struct golos_posting_api: base_contract_api {
         auto referral = get_str_referral_acc(name());
         auto curators_prcnt = get_str_curators_prcnt(min_curators_prcnt, max_curators_prcnt);
 
-        auto params = "[" + vote_changes + "," + cashout_window + "," + beneficiaries + "," + comment_depth + 
+        auto params = "[" + vote_changes + "," + cashout_window + "," + beneficiaries + "," + comment_depth +
             "," + social + "," + referral + "," + curators_prcnt + "]";
-        return set_params(params); 
-    } 
+        return set_params(params);
+    }
 
     variant get_params() const {
         return base_contract_api::get_struct(_code, N(pstngparams), N(pstngparams), "posting_state");
@@ -157,15 +157,15 @@ struct golos_posting_api: base_contract_api {
     string get_str_comment_depth(uint16_t max_comment_depth) {
         return string("['st_max_comment_depth', {'value':'") + std::to_string(max_comment_depth) + "'}]";
     }
-    
+
     string get_str_social_acc(name social_acc) {
         return string("['st_social_acc', {'value':'") + name{social_acc}.to_string() + "'}]";
     }
-    
+
     string get_str_referral_acc(name referral_acc) {
         return string("['st_referral_acc', {'value':'") + name{referral_acc}.to_string() + "'}]";
-    }   
-    
+    }
+
     string get_str_curators_prcnt(uint16_t min_curators_prcnt, uint16_t max_curators_prcnt) {
         return string("['st_curators_prcnt', {'min_curators_prcnt':'") + std::to_string(min_curators_prcnt) + "','max_curators_prcnt':'" + std::to_string(max_curators_prcnt) + "'}]";
     }
@@ -177,7 +177,7 @@ struct golos_posting_api: base_contract_api {
 
     variant get_message(mssgid message_id) {
         variant obj = _tester->get_chaindb_lower_bound_struct(_code, message_id.author, N(message), N(bypermlink),
-                                                                message_id.get_unique_key(), "message");        
+                                                                message_id.get_unique_key(), "message");
         if (!obj.is_null() && obj.get_object().size()) {
             if(obj["permlink"].as<std::string>() == message_id.permlink && obj["ref_block_num"].as<uint64_t>() == message_id.ref_block_num) {
                 return obj;

--- a/tests/golos.publication_rewards_tests.cpp
+++ b/tests/golos.publication_rewards_tests.cpp
@@ -16,7 +16,7 @@ using namespace eosio::testing;
 
 #define PRECESION 0
 #define TOKEN_NAME "GOLOS"
-constexpr int64_t MAXTOKENPROB = 5000;
+constexpr uint16_t MAXTOKENPROP = 5000;
 constexpr auto MAX_ARG = static_cast<double>(std::numeric_limits<fixp_t>::max());
 
 double log2(double arg) {
@@ -51,7 +51,7 @@ protected:
         const string not_monotonic      = amsg("check monotonic failed for time penalty func");
         const string fp_cast_overflow   = amsg("fp_cast: overflow");
         const string limit_no_power     = amsg("not enough power");
-        const string limit_no_vesting     = amsg("insufficient effective vesting amount");
+        const string limit_no_vesting   = amsg("insufficient effective vesting amount");
         const string delete_upvoted     = amsg("Cannot delete a comment with net positive votes.");
     } err;
 
@@ -196,7 +196,7 @@ public:
             produce_blocks();
         }
 
-        auto ret =  post.set_rules(mainfunc, curationfunc, timepenalty, MAXTOKENPROB);
+        auto ret =  post.set_rules(mainfunc, curationfunc, timepenalty, MAXTOKENPROP);
         if (ret == success()) {
             double unclaimed_funds = 0.0;
             for (auto& p : _state.pools) {
@@ -375,7 +375,7 @@ public:
                     auto author_payout =  payout - curation_payout;
                     double ben_payout_sum = 0.0;
                     for (auto& ben : m.beneficiaries) {
-                        double ben_payout = author_payout * get_prop(ben.deductprcnt);
+                        double ben_payout = author_payout * get_prop(ben.weight);
                         _state.balances[ben.account].vestamount += get_converted_to_vesting(ben_payout);
                         ben_payout_sum += ben_payout;
                     }
@@ -428,14 +428,14 @@ public:
         mssgid message_id,
         mssgid parent_message_id = {N(), "parentprmlnk", 0},
         vector<beneficiary> beneficiaries = {},
-        int64_t tokenprop = 5000,
+        uint16_t tokenprop = MAXTOKENPROP,
         bool vestpayment = false,
         std::string title = "headermssg",
         std::string body = "bodymssg",
         std::string language = "languagemssg",
         std::vector<std::string> tags = {"tag"},
         std::string json_metadata = "jsonmetadata",
-        double curators_prcnt = 7100 
+        uint16_t curators_prcnt = 7100
     ) {
         auto ref_block_num = control->head_block_header().block_num();
         const auto current_time = control->head_block_time().sec_since_epoch();
@@ -459,7 +459,7 @@ public:
         if (ret == success()) {
             _state.pools.back().messages.emplace_back(message(
                 message_id,
-                static_cast<double>(std::min(tokenprop, MAXTOKENPROB)) / static_cast<double>(cfg::_100percent),
+                static_cast<double>(tokenprop) / static_cast<double>(cfg::_100percent),
                 static_cast<double>(current_time),
                 beneficiaries, reward_weight,
                 static_cast<double>(curators_prcnt) / static_cast<double>(cfg::_100percent)));
@@ -543,7 +543,7 @@ BOOST_FIXTURE_TEST_CASE(basic_tests, reward_calcs_tester) try {
     BOOST_CHECK_EQUAL(success(), setrules({"x^2", static_cast<base_t>(sqrt(bignum))}, {"sqrt(x)", bignum}, {"1", bignum},
         [](double x){ return x * x; }, [](double x){ return sqrt(x); }, [](double x){ return 1.0; }));
     check();
-    
+
     BOOST_TEST_MESSAGE("--- create_message: bob4");
     auto ref_block_num_bob4 = control->head_block_header().block_num();
     BOOST_CHECK_EQUAL(success(), create_message({N(bob4), "permlink", ref_block_num_bob4}));
@@ -560,7 +560,7 @@ BOOST_FIXTURE_TEST_CASE(basic_tests, reward_calcs_tester) try {
     BOOST_TEST_MESSAGE("--- bob3 revoted (-100%) against bob4");
     BOOST_CHECK_EQUAL(success(), addvote(N(bob3), {N(bob4), "permlink", ref_block_num_bob4}, -10000));
     check();
-    
+
     BOOST_TEST_MESSAGE("--- create_message: alice");
     auto ref_block_num_alice = control->head_block_header().block_num();
     BOOST_CHECK_EQUAL(success(), create_message({N(alice), "permlink", ref_block_num_alice}));
@@ -690,14 +690,14 @@ BOOST_FIXTURE_TEST_CASE(limits_test, reward_calcs_tester) try {
             [](double p, double v, double t){ return sqrt(v / 500000.0) * (t / 150.0); }
         })
     );
-    
+
     auto create_msg = [&](
-            mssgid message_id, 
-            mssgid parent_id = {N(), "parentprmlnk", 0}, 
+            mssgid message_id,
+            mssgid parent_id = {N(), "parentprmlnk", 0},
             bool vest_payment = false,
-            uint16_t curators_prcnt = 0) { 
+            uint16_t curators_prcnt = 0) {
         return create_message(
-            message_id, 
+            message_id,
             parent_id,
             {},
             5000,
@@ -707,7 +707,7 @@ BOOST_FIXTURE_TEST_CASE(limits_test, reward_calcs_tester) try {
             "languagemssg",
             {{"tag"}},
             "jsonmetadata",
-            curators_prcnt    
+            curators_prcnt
             );
     };
 
@@ -721,7 +721,7 @@ BOOST_FIXTURE_TEST_CASE(limits_test, reward_calcs_tester) try {
     BOOST_CHECK_EQUAL(err.limit_no_power, create_msg({N(bob), "permlink2", ref_block_num_bob}));
     BOOST_TEST_MESSAGE("--- comments");
     for (size_t i = 0; i < 10; i++) {   // TODO: remove magic number, 10 must be derived from some constant used in rules
-        BOOST_CHECK_EQUAL(success(), create_msg({N(bob), "comment" + std::to_string(i), ref_block_num_bob}, 
+        BOOST_CHECK_EQUAL(success(), create_msg({N(bob), "comment" + std::to_string(i), ref_block_num_bob},
                                                 {N(bob), "permlink", ref_block_num_bob}));
     }
     BOOST_CHECK_EQUAL(err.limit_no_power, create_msg({N(bob), "oops", ref_block_num_bob},
@@ -811,7 +811,7 @@ BOOST_FIXTURE_TEST_CASE(message_netshares_overflow_test, reward_calcs_tester) tr
     BOOST_TEST_MESSAGE("--- add_funds_to_forum");
     BOOST_CHECK_EQUAL(success(), add_funds_to_forum(50000));
     check();
-    
+
     BOOST_TEST_MESSAGE("--- create_message: alice");
     auto ref_block_num = control->head_block_header().block_num();
     mssgid message_id{N(alice), "permlink", ref_block_num};
@@ -826,7 +826,7 @@ BOOST_FIXTURE_TEST_CASE(message_netshares_overflow_test, reward_calcs_tester) tr
         fill_from_tables(_res);
         BOOST_CHECK_EQUAL(_res[statemap::get_message_str(message_id) + "netshares"].val, _res.get_pool(pool_id).rshares);
         BOOST_CHECK_GT(_res[statemap::get_message_str(message_id) + "netshares"].val, 0);
-        BOOST_CHECK_GT( _res.get_pool(pool_id).rsharesfn, 0);   
+        BOOST_CHECK_GT( _res.get_pool(pool_id).rsharesfn, 0);
     }
     for (size_t i = 0; i < 10; i++) {
         BOOST_TEST_MESSAGE("--- " << name{_users[i]}.to_string() << " revoted for alice");
@@ -835,8 +835,8 @@ BOOST_FIXTURE_TEST_CASE(message_netshares_overflow_test, reward_calcs_tester) tr
         fill_from_tables(_res);
         BOOST_CHECK_EQUAL(_res[statemap::get_message_str(message_id) + "netshares"].val, _res.get_pool(pool_id).rshares);
         BOOST_CHECK_GT(_res[statemap::get_message_str(message_id) + "netshares"].val, 0);
-        BOOST_CHECK_GT( _res.get_pool(pool_id).rsharesfn, 0); 
-         
+        BOOST_CHECK_GT( _res.get_pool(pool_id).rsharesfn, 0);
+
     }
     for (size_t i = 10; i < 15; i++) {
         BOOST_TEST_MESSAGE("--- " << name{_users[i]}.to_string() << " voted against alice");
@@ -844,9 +844,9 @@ BOOST_FIXTURE_TEST_CASE(message_netshares_overflow_test, reward_calcs_tester) tr
         produce_block();
         fill_from_tables(_res);
         BOOST_CHECK_EQUAL(_res[statemap::get_message_str(message_id) + "netshares"].val, _res.get_pool(pool_id).rshares);
-        BOOST_CHECK_GE( _res.get_pool(pool_id).rsharesfn, 0);  
+        BOOST_CHECK_GE( _res.get_pool(pool_id).rsharesfn, 0);
     }
-    
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(golos_curation_test, reward_calcs_tester) try {

--- a/tests/golos.publication_rewards_types.hpp
+++ b/tests/golos.publication_rewards_types.hpp
@@ -177,7 +177,7 @@ struct vote {
 
 struct beneficiary {
     account_name account;
-    int64_t deductprcnt;
+    uint16_t weight;
 };
 
 struct message {
@@ -370,5 +370,5 @@ struct state {
 
 }} // eosio::testing
 
-FC_REFLECT(eosio::testing::beneficiary, (account)(deductprcnt))
+FC_REFLECT(eosio::testing::beneficiary, (account)(weight))
 FC_REFLECT(eosio::testing::mssgid, (author)(permlink)(ref_block_num))

--- a/tests/golos.publication_tests.cpp
+++ b/tests/golos.publication_tests.cpp
@@ -238,7 +238,6 @@ BOOST_FIXTURE_TEST_CASE(set_rules, golos_publication_tester) try {
     auto u = N(brucelee);
     vest.open(u, _sym, u);
     produce_block();
-    // auto ref = control->head_block_header().block_num();
 
     BOOST_CHECK_EQUAL(success(), post.create_msg({u, "100"},{N(),""}, {}, cfg::_100percent));
     BOOST_CHECK_EQUAL(err.invalid_percent("tokenprop"),
@@ -618,22 +617,22 @@ BOOST_FIXTURE_TEST_CASE(set_curators_prcnt, golos_publication_tester) try {
 
     BOOST_TEST_MESSAGE("--- checking that curators percent was setted as default");
     BOOST_CHECK_EQUAL(success(), create_msg());
-    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(post.min_curators_prcnt)/elai_t(cfg::_100percent)).data()));
+    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"})["curators_prcnt"], post.min_curators_prcnt);
 
     BOOST_TEST_MESSAGE("--- checking that curators percent was setted correctly");
     BOOST_CHECK_EQUAL(success(), create_msg(7100, {N(jackiechan), "permlink"}));
-    BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "permlink"})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(7100)/elai_t(cfg::_100percent)).data()));
+    BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "permlink"})["curators_prcnt"], 7100);
 
     BOOST_TEST_MESSAGE("--- checking that curators percent was changed");
     BOOST_CHECK_EQUAL(success(), post.set_curators_prcnt({N(brucelee), "permlink"}, 7300));
-    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(7300)/elai_t(cfg::_100percent)).data()));
+    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"})["curators_prcnt"], 7300);
 
     BOOST_TEST_MESSAGE("--- checking that curators percent can't be changed");
     BOOST_CHECK_EQUAL(success(), token.issue(cfg::emission_name, N(jackiechan), token.make_asset(500), "issue tokens jackiechan"));
     BOOST_CHECK_EQUAL(success(), token.transfer(N(jackiechan), cfg::vesting_name, token.make_asset(100), "buy vesting"));
     BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), {N(brucelee), "permlink"}, 123));
     BOOST_CHECK_EQUAL(err.no_cur_percent, post.set_curators_prcnt({N(brucelee), "permlink"}, 7500));
-    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(7300)/elai_t(cfg::_100percent)).data()));
+    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"})["curators_prcnt"], 7300);
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/golos.referral_tests.cpp
+++ b/tests/golos.referral_tests.cpp
@@ -56,7 +56,7 @@ public:
 
     void init_params_posts() {
         funcparams fn{"0", 1};
-        BOOST_CHECK_EQUAL(success(), post.set_rules(fn ,fn ,fn , 0));
+        BOOST_CHECK_EQUAL(success(), post.set_rules(fn ,fn ,fn , 5000));
         BOOST_CHECK_EQUAL(success(), post.set_limit("post"));
         BOOST_CHECK_EQUAL(success(), post.set_limit("comment"));
         BOOST_CHECK_EQUAL(success(), post.set_limit("vote"));
@@ -96,9 +96,9 @@ protected:
         const string limit_persent     = amsg("max_percent > 100.00%");
 
         const string referral_not_exist      = amsg("A referral with this name doesn't exist.");
-        const string funds_not_equal         = amsg("Amount of funds doesn't equal.");
-        const string limit_percents          = amsg("publication::create_message: prop_sum > 100%");
-        const string referrer_benif          = amsg("Comment already has referrer as a referrer-beneficiary.");
+        const string funds_not_equal   = amsg("Amount of funds doesn't equal.");
+        const string limit_percents    = amsg("weights_sum + referral percent must not be greater than 100% (10000)");
+        const string referrer_benif    = amsg("Comment already has referrer as a referrer-beneficiary.");
     } err;
 
     golos_posting_api post;

--- a/tests/golos.social_tests.cpp
+++ b/tests/golos.social_tests.cpp
@@ -58,7 +58,7 @@ public:
         BOOST_CHECK_EQUAL(success(), vest.create_vesting("issuer"_n));
 
         funcparams fn{"0", 1};
-        BOOST_CHECK_EQUAL(success(), post.set_rules(fn, fn, fn, 0));
+        BOOST_CHECK_EQUAL(success(), post.set_rules(fn, fn, fn, 5000));
         BOOST_CHECK_EQUAL(success(), post.set_limit("post"));
         BOOST_CHECK_EQUAL(success(), post.set_limit("comment"));
         BOOST_CHECK_EQUAL(success(), post.set_limit("vote"));

--- a/tests/golos_tester.hpp
+++ b/tests/golos_tester.hpp
@@ -37,7 +37,7 @@ struct permission {
 
 struct contract_error_messages {
 protected:
-    const string amsg(const string& x) { return base_tester::wasm_assert_msg(x); }
+    const string amsg(const string& x) const { return base_tester::wasm_assert_msg(x); }
 };
 
 


### PR DESCRIPTION
+ `createmssg`: removed ability to have several beneficiaries with the same name (it increases chance to send wrong action. is there any profit in it?)
+ ABI change: beneficiary `deductprcnt` field renamed to `weight`, it's type now `uint16_t`
+ ABI change: `tokenprop` and `curators_prcnt` types are now `uint16_t` in `createmssg` action
+ ABI change: `maxtokenprop` parameter is now `uint16_t`
+ ABI change `rewardweight` type is now `uint16_t` in both messages table and EE
+ in `set_curators_prcnt` check, that percent actually differs
+ added parameters caching mechanism to fetch data from db once
+ Tables: `childcount` is now `uint32_t`, `voteinfo.count` is now `uint8_t`
+ added `percent_t` and `signed_percent_t` aliases to abi
+ added test to validate `curators_prcnt` in `setrules`
+ added helpers to check percent value, `get_limit_prop` (which allows percents > 100%) removed
+ some posting methods are `static` now
+ some comments on elastic types
+ minor refactoring and spacekill