### PR TITLE
Archive for closed posts. #622

### DIFF
--- a/docs/ru-RU/golos.publication_contract.md
+++ b/docs/ru-RU/golos.publication_contract.md
@@ -71,7 +71,7 @@ void createmssg(
     bool 		    vestpayment,
     std::string 	headermssg,
     std::string 	bodymssg,
-    std::string l	anguagemssg,
+    std::string     languagemssg,
     std::vector<std::string> tags,
     std::string 	jsonmetadata
 );

--- a/golos.publication/golos.publication.abi
+++ b/golos.publication/golos.publication.abi
@@ -42,10 +42,6 @@
         {
             "name": "permlink",
             "type": "string"
-        },
-        {
-            "name": "ref_block_num",
-            "type": "uint64"
         }
     ]
   },
@@ -180,10 +176,6 @@
         "type": "string"
       },
       {
-        "name": "ref_block_num",
-        "type": "uint64"
-      },
-      {
         "name": "date",
         "type": "uint64"
       },
@@ -226,6 +218,24 @@
     ]
   },
   {
+      "name": "permlink",
+      "base": "",
+      "fields": [
+        {
+          "name": "id",
+          "type": "uint64"
+        },
+        {
+          "name": "value",
+          "type": "string"
+        },
+        {
+          "name": "level",
+          "type": "uint16"
+        }
+      ]
+  },
+  {
     "name": "createmssg",
     "base": "",
     "fields": [
@@ -236,10 +246,6 @@
       {
         "name": "parent_id",
         "type": "mssgid"
-      },
-      {
-        "name": "parent_recid",
-        "type": "uint64"
       },
       {
         "name": "beneficiaries",
@@ -742,13 +748,6 @@
     ]
   },
   {
-    "name": "create_event",
-    "base": "",
-    "fields": [
-        {"name": "record_id", "type": "uint64"}
-    ]
-  },
-  {
     "name": "post_event",
     "base": "",
     "fields": [
@@ -794,7 +793,6 @@
   "events": [
     {"name": "poolstate", "type": "pool_event"},
     {"name": "poolerase", "type": "uint64"},
-    {"name": "postcreate","type": "create_event"},
     {"name": "poststate", "type": "post_event"},
     {"name": "votestate", "type": "vote_event"},
     {"name": "rewardweight", "type": "reward_weight_event"}
@@ -873,11 +871,30 @@
           "name": "bypermlink",
           "unique": "true",
           "orders": [
-              {"field": "permlink", "order": "asc"},
-              {"field": "ref_block_num", "order": "asc"}
+              {"field": "permlink", "order": "asc"}
           ]
        }
     ]
+  },
+  {
+      "name": "permlink",
+      "type": "permlink",
+      "indexes": [
+         {
+            "name": "primary",
+            "unique": "true",
+            "orders": [
+                {"field": "id", "order": "asc"}
+            ]
+         },
+         {
+            "name": "byvalue",
+            "unique": "true",
+            "orders": [
+                {"field": "value", "order": "asc"}
+            ]
+         }
+      ]
   },
   {
     "name": "vote",

--- a/golos.publication/golos.publication.hpp
+++ b/golos.publication/golos.publication.hpp
@@ -14,7 +14,7 @@ public:
     void set_rules(const funcparams& mainfunc, const funcparams& curationfunc, const funcparams& timepenalty,
         int64_t maxtokenprop, symbol tokensymbol);
     void on_transfer(name from, name to, asset quantity, std::string memo = "");
-    void create_message(structures::mssgid message_id, structures::mssgid parent_id, uint64_t parent_recid,
+    void create_message(structures::mssgid message_id, structures::mssgid parent_id,
         std::vector<structures::beneficiary> beneficiaries, int64_t tokenprop, bool vestpayment,
         std::string headermssg, std::string bodymssg, std::string languagemssg, std::vector<std::string> tags,
         std::string jsonmetadata, std::optional<uint16_t> curators_prcnt);

--- a/golos.publication/objects.hpp
+++ b/golos.publication/objects.hpp
@@ -23,23 +23,14 @@ struct mssgid {
 
     name author;
     std::string permlink;
-    uint64_t ref_block_num;
 
     bool operator==(const mssgid& value) const {
         return author == value.author &&
-               permlink == value.permlink &&
-               ref_block_num == value.ref_block_num;
+               permlink == value.permlink;
     }
 
-    EOSLIB_SERIALIZE(mssgid, (author)(permlink)(ref_block_num))
+    EOSLIB_SERIALIZE(mssgid, (author)(permlink))
 };
-
-struct archive_info_v1 {
-    mssgid id;
-    uint16_t level;
-};
-
-using archive_record = std::variant<archive_info_v1>;
 
 struct messagestate {
     base_t netshares = 0;
@@ -52,7 +43,6 @@ struct message {
 
     uint64_t id;
     std::string permlink;
-    uint64_t ref_block_num;
     uint64_t date;
     name parentacc;
     uint64_t parent_id;
@@ -68,8 +58,24 @@ struct message {
         return id;
     }
     
-    std::tuple<std::string, uint64_t> secondary_key() const {
-        return {permlink, ref_block_num};
+    std::string secondary_key() const {
+        return permlink;
+    }
+};
+
+struct permlink {
+    permlink() = default;
+
+    uint64_t id;
+    std::string value;
+    uint16_t level;
+
+    uint64_t primary_key() const {
+        return id;
+    }
+
+    std::string secondary_key() const {
+        return value;
     }
 };
 
@@ -145,10 +151,6 @@ struct rewardpool {
     EOSLIB_SERIALIZE(rewardpool, (created)(rules)(state))
 };
 
-struct create_event {
-    uint64_t record_id;
-};
-
 struct post_event {
     name author;
     std::string permlink;
@@ -206,8 +208,12 @@ namespace tables {
 using namespace eosio;
 
 using id_index = indexed_by<N(primary), const_mem_fun<structures::message, uint64_t, &structures::message::primary_key>>;
-using permlink_index = indexed_by<N(bypermlink), const_mem_fun<structures::message, std::tuple<std::string, uint64_t>, &structures::message::secondary_key>>;
+using permlink_index = indexed_by<N(bypermlink), const_mem_fun<structures::message, std::string, &structures::message::secondary_key>>;
 using message_table = multi_index<N(message), structures::message, id_index, permlink_index>;
+
+using permlink_id_index = indexed_by<N(primary), const_mem_fun<structures::permlink, uint64_t, &structures::permlink::primary_key>>;
+using permlink_value_index = indexed_by<N(byvalue), const_mem_fun<structures::permlink, std::string, &structures::permlink::secondary_key>>;
+using permlink_table = multi_index<N(permlink), structures::permlink, permlink_id_index, permlink_value_index>;
 
 using vote_id_index = indexed_by<N(id), const_mem_fun<structures::voteinfo, uint64_t, &structures::voteinfo::primary_key>>;
 using vote_messageid_index = indexed_by<N(messageid), const_mem_fun<structures::voteinfo, uint64_t, &structures::voteinfo::by_message>>;

--- a/tests/golos.posting_test_api.hpp
+++ b/tests/golos.posting_test_api.hpp
@@ -40,8 +40,7 @@ struct golos_posting_api: base_contract_api {
 
     action_result create_msg(
         mssgid message_id,
-        mssgid parent_id = {N(), "parentprmlnk", 0},
-        uint64_t parent_recid = 0,
+        mssgid parent_id = {N(), "parentprmlnk"},
         std::vector<beneficiary> beneficiaries = {},
         int64_t token_prop = 5000,
         bool vest_payment = false,
@@ -55,7 +54,6 @@ struct golos_posting_api: base_contract_api {
         return push(N(createmssg), message_id.author, args()
             ("message_id", message_id)
             ("parent_id", parent_id)
-            ("parent_recid", parent_recid)
             ("beneficiaries", beneficiaries)
             ("tokenprop", token_prop)
             ("vestpayment", vest_payment)
@@ -179,7 +177,7 @@ struct golos_posting_api: base_contract_api {
         variant obj = _tester->get_chaindb_lower_bound_struct(_code, message_id.author, N(message), N(bypermlink),
                                                                 message_id.get_unique_key(), "message");        
         if (!obj.is_null() && obj.get_object().size()) {
-            if(obj["permlink"].as<std::string>() == message_id.permlink && obj["ref_block_num"].as<uint64_t>() == message_id.ref_block_num) {
+            if(obj["permlink"].as<std::string>() == message_id.permlink) {
                 return obj;
             }
         }

--- a/tests/golos.publication_rewards_types.hpp
+++ b/tests/golos.publication_rewards_types.hpp
@@ -52,14 +52,13 @@ inline double get_prop(int64_t arg) {
 struct mssgid {
     eosio::chain::name author;
     std::string permlink;
-    uint64_t ref_block_num;
 
     auto get_unique_key() const {
-        return std::pair<std::string, uint64_t>(permlink, ref_block_num);
+        return permlink;
     }
 
     bool operator ==(const mssgid& rhs) const {
-        return author == rhs.author && permlink == rhs.permlink && ref_block_num == rhs.ref_block_num;
+        return author == rhs.author && permlink == rhs.permlink;
     }
 };
 
@@ -101,10 +100,10 @@ struct statemap : public std::map<std::string, aprox_val_t> {
         return "balance of " +  acc.to_string() + ": ";
     }
     static std::string get_message_str(const mssgid& msg) {
-        return "message of " + msg.author.to_string() + " #" + msg.permlink + ", " + std::to_string(msg.ref_block_num) + ": ";
+        return "message of " + msg.author.to_string() + " #" + msg.permlink + ": ";
     }
     static std::string get_vote_str(account_name voter, const mssgid& msg) {
-        return "vote of " + voter.to_string() + " for message of " + msg.author.to_string() + " #" + msg.permlink + ", " + std::to_string(msg.ref_block_num) + ": ";
+        return "vote of " + voter.to_string() + " for message of " + msg.author.to_string() + " #" + msg.permlink + ": ";
     }
     void set_pool(uint64_t id, const pool_data& data = {}) {
         auto prefix = get_pool_str(id);
@@ -371,4 +370,4 @@ struct state {
 }} // eosio::testing
 
 FC_REFLECT(eosio::testing::beneficiary, (account)(deductprcnt))
-FC_REFLECT(eosio::testing::mssgid, (author)(permlink)(ref_block_num))
+FC_REFLECT(eosio::testing::mssgid, (author)(permlink))

--- a/tests/golos.publication_tests.cpp
+++ b/tests/golos.publication_tests.cpp
@@ -137,7 +137,7 @@ protected:
         const string no_content            = amsg("Content doesn't exist.");
 
         const string delete_children       = amsg("You can't delete comment with child comments.");
-        const string no_message            = amsg("Message doesn't exist.");
+        const string no_message            = amsg("Message doesn't exist in cashout window.");
         const string vote_same_weight      = amsg("Vote with the same weight has already existed.");
         const string vote_weight_0         = amsg("weight can't be 0.");
         const string vote_weight_gt100     = amsg("weight can't be more than 100%.");
@@ -149,7 +149,6 @@ protected:
         const string max_cmmnt_dpth_less_0 = amsg("Max comment depth must be greater than 0.");
         const string no_social_acc         = amsg("Social account doesn't exist.");
         const string no_referral_acc       = amsg("Referral account doesn't exist.");
-        const string not_valid_ref_block_num = amsg("ref_block_num mismatch");
         const string wrong_prmlnk_length   = amsg("Permlink length is empty or more than 256.");
         const string wrong_prmlnk          = amsg("Permlink contains wrong symbol.");
         const string wrong_title_length    = amsg("Title length is more than 256.");
@@ -222,55 +221,46 @@ BOOST_FIXTURE_TEST_CASE(set_params, golos_publication_tester) try {
 BOOST_FIXTURE_TEST_CASE(create_message, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Create message testing.");
     init();
-    auto ref_block_num_brucelee_and_chucknorris = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(err.not_valid_ref_block_num, post.create_msg({N(brucelee), "permlink", ref_block_num_brucelee_and_chucknorris+1}));
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink", ref_block_num_brucelee_and_chucknorris}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink"}));
 
     BOOST_TEST_MESSAGE("--- checking that another user can create a message with the same permlink.");
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(chucknorris), "permlink", ref_block_num_brucelee_and_chucknorris}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(chucknorris), "permlink"}));
 
-    check_equal_post(post.get_message({N(brucelee), "permlink", ref_block_num_brucelee_and_chucknorris}), _test_msg);
+    check_equal_post(post.get_message({N(brucelee), "permlink"}), _test_msg);
 
     BOOST_TEST_MESSAGE("--- checking that message wasn't closed.");
     produce_blocks(seconds_to_blocks(post.window));
-    auto msg = post.get_message({N(brucelee), "permlink", ref_block_num_brucelee_and_chucknorris});
+    auto msg = post.get_message({N(brucelee), "permlink"});
     BOOST_CHECK_EQUAL(msg.is_null(), false);
 
-    auto ref_block_num_jackiechan = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(jackiechan), "permlink1", ref_block_num_jackiechan},
-    {N(brucelee), "permlink", ref_block_num_brucelee_and_chucknorris}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(jackiechan), "permlink1"}, {N(brucelee), "permlink"}));
 
-    msg = post.get_message({N(brucelee), "permlink", ref_block_num_brucelee_and_chucknorris});
+    msg = post.get_message({N(brucelee), "permlink"});
     BOOST_CHECK_EQUAL(msg["childcount"].as<uint64_t>(), 1);
 
     BOOST_TEST_MESSAGE("--- checking that message was closed.");
     produce_block();
-    msg = post.get_message({N(brucelee), "permlink", ref_block_num_brucelee_and_chucknorris});
+    msg = post.get_message({N(brucelee), "permlink"});
     BOOST_CHECK_EQUAL(msg.is_null(), true);
 
-    auto ref_block_num_jackiechan_and_larimer = control->head_block_header().block_num();
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(jackiechan), "permlink2"}, {N(brucelee), "permlink"}));
 
-    BOOST_CHECK_EQUAL(err.parent_no_message, post.create_msg({N(jackiechan), "permlink2", ref_block_num_jackiechan_and_larimer},
-    {N(brucelee), "permlink", ref_block_num_brucelee_and_chucknorris}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(jackiechan), "permlink3"}, {N(brucelee), "permlink"}));
 
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(jackiechan), "permlink2", ref_block_num_jackiechan_and_larimer},
-    {N(brucelee), "permlink", ref_block_num_brucelee_and_chucknorris}, static_cast<uint64_t>(ref_block_num_brucelee_and_chucknorris+1)<<32 | 1));
-
-    BOOST_CHECK_EQUAL(err.unregistered_user_ + "dan.larimer", post.create_msg({N(dan.larimer), "hi", ref_block_num_jackiechan_and_larimer}));
+    BOOST_CHECK_EQUAL(err.unregistered_user_ + "dan.larimer", post.create_msg({N(dan.larimer), "hi"}));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(update_message, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Update message testing.");
     init();
 
-    auto ref_block_num = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink", ref_block_num}));
-    BOOST_CHECK_EQUAL(success(), post.update_msg({N(brucelee), "permlink", ref_block_num},
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink"}));
+    BOOST_CHECK_EQUAL(success(), post.update_msg({N(brucelee), "permlink"},
         "headermssgnew", "bodymssgnew", "languagemssgnew", {{"tagnew"}}, "jsonmetadatanew"));
 
     produce_blocks(seconds_to_blocks(post.window) + 1);
 
-    BOOST_CHECK_EQUAL(err.no_message, post.update_msg({N(brucelee), "permlink", ref_block_num},
+    BOOST_CHECK_EQUAL(success(), post.update_msg({N(brucelee), "permlink"},
         "headermssgnew", "bodymssgnew", "languagemssgnew", {{"tagnew"}}, "jsonmetadatanew"));
 
 } FC_LOG_AND_RETHROW()
@@ -279,18 +269,17 @@ BOOST_FIXTURE_TEST_CASE(delete_message, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Delete message testing.");
     init();
 
-    auto ref_block_num = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink", ref_block_num}));
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(jackiechan), "child", ref_block_num}, {N(brucelee), "permlink", ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink"}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(jackiechan), "child"}, {N(brucelee), "permlink"}));
 
     BOOST_TEST_MESSAGE("--- fail then delete non-existing post and post with child");
-    BOOST_CHECK_EQUAL(err.no_message, post.delete_msg({N(jackiechan), "permlink1", ref_block_num}));
-    BOOST_CHECK_EQUAL(err.delete_children, post.delete_msg({N(brucelee), "permlink", ref_block_num}));
+    BOOST_CHECK_EQUAL(err.no_message, post.delete_msg({N(jackiechan), "permlink1"}));
+    BOOST_CHECK_EQUAL(err.delete_children, post.delete_msg({N(brucelee), "permlink"}));
 
     BOOST_TEST_MESSAGE("--- success when delete child");
-    BOOST_CHECK_EQUAL(success(), post.delete_msg({N(jackiechan), "child", ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.delete_msg({N(jackiechan), "child"}));
     BOOST_TEST_MESSAGE("--- success delete when no more children");
-    BOOST_CHECK_EQUAL(success(), post.delete_msg({N(brucelee), "permlink", ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.delete_msg({N(brucelee), "permlink"}));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(upvote, golos_publication_tester) try {
@@ -298,16 +287,15 @@ BOOST_FIXTURE_TEST_CASE(upvote, golos_publication_tester) try {
     init();
 
     auto permlink = "permlink";
-    auto ref_block_num = control->head_block_header().block_num();
-    auto vote_brucelee = [&](auto weight){ return post.upvote(N(brucelee), {N(brucelee), permlink, ref_block_num}, weight); };
-    auto vote_jackie = [&](auto weight){ return post.upvote(N(jackiechan), {N(brucelee), permlink, ref_block_num}, weight); };
+    auto vote_brucelee = [&](auto weight){ return post.upvote(N(brucelee), {N(brucelee), permlink}, weight); };
+    auto vote_jackie = [&](auto weight){ return post.upvote(N(jackiechan), {N(brucelee), permlink}, weight); };
 
     BOOST_TEST_MESSAGE("--- fail on non-existing message");
     BOOST_CHECK_EQUAL(err.no_message, vote_brucelee(123));
     BOOST_TEST_CHECK(post.get_vote(N(brucelee), 1).is_null());
 
     BOOST_TEST_MESSAGE("--- succeed on initial upvote");
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), permlink, ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), permlink}));
     BOOST_CHECK_EQUAL(success(), vote_brucelee(123));
     auto _vote = mvo()("id",0)("message_id",1)("voter","brucelee")("count",1);   // TODO: time
     CHECK_MATCHING_OBJECT(post.get_vote(N(brucelee), 0), _vote);
@@ -347,16 +335,15 @@ BOOST_FIXTURE_TEST_CASE(downvote, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Downvote testing.");
     init();
     auto permlink = "permlink";
-    auto ref_block_num = control->head_block_header().block_num();
-    auto vote_brucelee = [&](auto weight){ return post.upvote(N(brucelee), {N(brucelee), permlink, ref_block_num}, weight); };
-    auto vote_jackie = [&](auto weight){ return post.upvote(N(jackiechan), {N(brucelee), permlink, ref_block_num}, weight); };
+    auto vote_brucelee = [&](auto weight){ return post.upvote(N(brucelee), {N(brucelee), permlink}, weight); };
+    auto vote_jackie = [&](auto weight){ return post.upvote(N(jackiechan), {N(brucelee), permlink}, weight); };
 
     BOOST_TEST_MESSAGE("--- fail on non-existing message");
     BOOST_CHECK_EQUAL(err.no_message, vote_brucelee(123));
     BOOST_TEST_CHECK(post.get_vote(N(brucelee), 1).is_null());
 
     BOOST_TEST_MESSAGE("--- succeed on initial downvote");
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), permlink, ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), permlink}));
     BOOST_CHECK_EQUAL(success(), vote_brucelee(123));
     auto _vote = mvo()("id",0)("message_id",1)("voter","brucelee")("count",1);   // TODO: time
     CHECK_MATCHING_OBJECT(post.get_vote(N(brucelee), 0), _vote);
@@ -389,34 +376,32 @@ BOOST_FIXTURE_TEST_CASE(downvote, golos_publication_tester) try {
 BOOST_FIXTURE_TEST_CASE(unvote, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Unvote testing.");
     init();
-    auto ref_block_num = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(err.no_message, post.unvote(N(brucelee), {N(brucelee), "permlink", ref_block_num}));
+    BOOST_CHECK_EQUAL(err.no_message, post.unvote(N(brucelee), {N(brucelee), "permlink"}));
 
     // TODO: test fail on initial unvote
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink", ref_block_num}));
-    BOOST_CHECK_EQUAL(success(), post.upvote(N(brucelee), {N(brucelee), "permlink", ref_block_num}, 123));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink"}));
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(brucelee), {N(brucelee), "permlink"}, 123));
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.unvote(N(brucelee), {N(brucelee), "permlink", ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.unvote(N(brucelee), {N(brucelee), "permlink"}));
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), {N(brucelee), "permlink", ref_block_num}, 333));
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), {N(brucelee), "permlink"}, 333));
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.unvote(N(brucelee), {N(brucelee), "permlink", ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.unvote(N(brucelee), {N(brucelee), "permlink"}));
     produce_block();
 
-    BOOST_CHECK_EQUAL(err.vote_same_weight, post.unvote(N(brucelee), {N(brucelee), "permlink", ref_block_num}));
+    BOOST_CHECK_EQUAL(err.vote_same_weight, post.unvote(N(brucelee), {N(brucelee), "permlink"}));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(mixed_vote_test, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Mixed vote testing.");
     init();
-    auto ref_block_num = control->head_block_header().block_num();
     BOOST_TEST_MESSAGE("--- test that each vote type increases votes count");
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink", ref_block_num}));
-    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), {N(brucelee), "permlink", ref_block_num}, 123));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink"}));
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), {N(brucelee), "permlink"}, 123));
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.unvote(N(brucelee), {N(brucelee), "permlink", ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.unvote(N(brucelee), {N(brucelee), "permlink"}));
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.upvote(N(brucelee), {N(brucelee), "permlink", ref_block_num}, 321));
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(brucelee), {N(brucelee), "permlink"}, 321));
     produce_block();
 
     auto vote = post.get_vote(N(brucelee), 0);
@@ -426,104 +411,100 @@ BOOST_FIXTURE_TEST_CASE(mixed_vote_test, golos_publication_tester) try {
 BOOST_FIXTURE_TEST_CASE(delete_post_with_vote_test, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Delete post with vote testing.");   // TODO: move to "delete" test ?
     init();
-    auto ref_block_num = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "upvote-me", ref_block_num}));
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(chucknorris), "downvote-me", ref_block_num}));
-    BOOST_CHECK_EQUAL(success(), post.upvote(N(chucknorris), {N(brucelee), "upvote-me", ref_block_num}, 321));
-    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), {N(chucknorris), "downvote-me", ref_block_num}, 123));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "upvote-me"}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(chucknorris), "downvote-me"}));
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(chucknorris), {N(brucelee), "upvote-me"}, 321));
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), {N(chucknorris), "downvote-me"}, 123));
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.delete_msg({N(chucknorris), "downvote-me", ref_block_num}));
-//    BOOST_CHECK_EQUAL(err.delete_rshares, post.delete_msg({N(brucelee), "upvote-me", ref_block_num}));    // TODO:
+    BOOST_CHECK_EQUAL(success(), post.delete_msg({N(chucknorris), "downvote-me"}));
+//    BOOST_CHECK_EQUAL(err.delete_rshares, post.delete_msg({N(brucelee), "upvote-me"}));    // TODO:
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(nesting_level_test, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("nesting level test.");
     init();
-    auto ref_block_num = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink0", ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink0"}));
     size_t i = 0;
     for (; i < post.max_comment_depth; i++) {
         BOOST_CHECK_EQUAL(success(), post.create_msg(
-            {N(brucelee), "permlink" + std::to_string(i+1), ref_block_num},
-            {N(brucelee), "permlink" + std::to_string(i), ref_block_num}));
+            {N(brucelee), "permlink" + std::to_string(i+1)},
+            {N(brucelee), "permlink" + std::to_string(i)}));
     }
     BOOST_CHECK_EQUAL(err.max_comment_depth, post.create_msg(
-        {N(brucelee), "permlink" + std::to_string(i+1), ref_block_num},
-        {N(brucelee), "permlink" + std::to_string(i), ref_block_num}));
+        {N(brucelee), "permlink" + std::to_string(i+1)},
+        {N(brucelee), "permlink" + std::to_string(i)}));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(comments_cashout_time_test, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("comments_cashout_time_test.");
     init();
-    auto ref_block_num_brucelee = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink", ref_block_num_brucelee}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink"}));
     auto need_blocks = seconds_to_blocks(post.window);
     auto wait_blocks = 5;
     produce_blocks(wait_blocks);
     need_blocks -= wait_blocks;
 
-    auto ref_block_num_chucknorris = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(chucknorris), "comment-permlink", ref_block_num_chucknorris},
-                                                 {N(brucelee), "permlink", ref_block_num_brucelee}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(chucknorris), "comment-permlink"}, {N(brucelee), "permlink"}));
         
     BOOST_TEST_MESSAGE("--- creating " << need_blocks << " blocks");
     produce_blocks(need_blocks);
     
     BOOST_TEST_MESSAGE("--- checking that messages wasn't closed.");
-    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink", ref_block_num_brucelee}).is_null(), false);
+    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"}).is_null(), false);
     
     produce_block();
     
     BOOST_TEST_MESSAGE("--- checking that messages was closed.");
-    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink", ref_block_num_brucelee}).is_null(), true);
+    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"}).is_null(), true);
 
     produce_blocks(wait_blocks-1);
     BOOST_TEST_MESSAGE("--- checking that comment wasn't closed.");
-    BOOST_CHECK_EQUAL(post.get_message({N(chucknorris), "comment-permlink", ref_block_num_chucknorris}).is_null(), false);
+    BOOST_CHECK_EQUAL(post.get_message({N(chucknorris), "comment-permlink"}).is_null(), false);
 
     produce_block();
     BOOST_TEST_MESSAGE("--- checking that comment was closed.");
-    BOOST_CHECK_EQUAL(post.get_message({N(chucknorris), "comment-permlink", ref_block_num_chucknorris}).is_null(), true);
+    BOOST_CHECK_EQUAL(post.get_message({N(chucknorris), "comment-permlink"}).is_null(), true);
     
-    auto ref_block_num_jackiechan = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(err.parent_no_message, post.create_msg({N(jackiechan), "sorry-guys-i-am-late", ref_block_num_jackiechan},
-                                                 {N(brucelee), "permlink", ref_block_num_brucelee}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(jackiechan), "sorry-guys-i-am-late"}, {N(brucelee), "permlink"}));
+    produce_blocks(need_blocks);
+    BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "sorry-guys-i-am-late"}).is_null(), false);
     produce_block();
-    
+
+    produce_blocks(wait_blocks - 1);
+    BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "sorry-guys-i-am-late"}).is_null(), false);
+
     BOOST_TEST_MESSAGE("--- checking that closed message comment was closed.");
-    BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "sorry-guys-i-am-late", ref_block_num_jackiechan}).is_null(), true);
+    produce_block();
+    BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "sorry-guys-i-am-late"}).is_null(), true);
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(data_validation, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("data_validation_test.");
     init();
-    auto ref_block_num_brucelee = control->head_block_header().block_num();
     std::string str256(256, 'a');
 
     BOOST_TEST_MESSAGE("--- checking permlink length.");
-    BOOST_CHECK_EQUAL(err.wrong_prmlnk_length, post.create_msg({N(brucelee), "", ref_block_num_brucelee}));
-    BOOST_CHECK_EQUAL(err.wrong_prmlnk_length, post.create_msg({N(brucelee), str256, ref_block_num_brucelee}));
+    BOOST_CHECK_EQUAL(err.wrong_prmlnk_length, post.create_msg({N(brucelee), ""}));
+    BOOST_CHECK_EQUAL(err.wrong_prmlnk_length, post.create_msg({N(brucelee), str256}));
 
     BOOST_TEST_MESSAGE("--- checking permlink naming convension.");
-    BOOST_CHECK_EQUAL(err.wrong_prmlnk, post.create_msg({N(brucelee), "ABC", ref_block_num_brucelee}));
-    BOOST_CHECK_EQUAL(err.wrong_prmlnk, post.create_msg({N(brucelee), "АБЦ", ref_block_num_brucelee}));
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "abcdefghijklmnopqrstuvwxyz0123456789-", ref_block_num_brucelee}));
+    BOOST_CHECK_EQUAL(err.wrong_prmlnk, post.create_msg({N(brucelee), "ABC"}));
+    BOOST_CHECK_EQUAL(err.wrong_prmlnk, post.create_msg({N(brucelee), "АБЦ"}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "abcdefghijklmnopqrstuvwxyz0123456789-"}));
 
     BOOST_TEST_MESSAGE("--- checking title length.");
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink", ref_block_num_brucelee}));
-    BOOST_CHECK_EQUAL(err.wrong_title_length, post.create_msg({N(brucelee), "test-title", ref_block_num_brucelee},
-                                                              {N(brucelee), "permlink", ref_block_num_brucelee},
-                                                              0,
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink"}));
+    BOOST_CHECK_EQUAL(err.wrong_title_length, post.create_msg({N(brucelee), "test-title"},
+                                                              {N(brucelee), "permlink"},
                                                               {},
                                                               5000,
                                                               false,
                                                               str256));
 
     BOOST_TEST_MESSAGE("--- checking body length.");
-    BOOST_CHECK_EQUAL(err.wrong_body_length, post.create_msg({N(brucelee), "test-body", ref_block_num_brucelee},
-                                                             {N(brucelee), "permlink", ref_block_num_brucelee},
-                                                             0,
+    BOOST_CHECK_EQUAL(err.wrong_body_length, post.create_msg({N(brucelee), "test-body"},
+                                                             {N(brucelee), "permlink"},
                                                              {},
                                                              5000,
                                                              false,
@@ -536,7 +517,6 @@ BOOST_FIXTURE_TEST_CASE(upvote_near_close, golos_publication_tester) try {
     init();
 
     auto permlink = "permlink";
-    auto ref_block_num = control->head_block_header().block_num();
 
     BOOST_CHECK_EQUAL(success(), token.issue(cfg::emission_name, N(brucelee), token.make_asset(500), "issue tokens brucelee"));
     BOOST_CHECK_EQUAL(success(), token.issue(cfg::emission_name, N(jackiechan), token.make_asset(500), "issue tokens jackiechan"));
@@ -548,12 +528,12 @@ BOOST_FIXTURE_TEST_CASE(upvote_near_close, golos_publication_tester) try {
     BOOST_CHECK_EQUAL(success(), token.transfer(N(chucknorris), cfg::vesting_name, token.make_asset(100), "buy vesting"));
     produce_block();
 
-    auto vote_brucelee = [&](auto weight){ return post.upvote(N(brucelee), {N(brucelee), permlink, ref_block_num}, weight); };
-    auto vote_jackie = [&](auto weight){ return post.upvote(N(jackiechan), {N(brucelee), permlink, ref_block_num}, weight); };
-    auto vote_chucknorris = [&](auto weight){ return post.upvote(N(chucknorris), {N(brucelee), permlink, ref_block_num}, weight); };
+    auto vote_brucelee = [&](auto weight){ return post.upvote(N(brucelee), {N(brucelee), permlink}, weight); };
+    auto vote_jackie = [&](auto weight){ return post.upvote(N(jackiechan), {N(brucelee), permlink}, weight); };
+    auto vote_chucknorris = [&](auto weight){ return post.upvote(N(chucknorris), {N(brucelee), permlink}, weight); };
 
     BOOST_TEST_MESSAGE("--- succeed on initial upvote");
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), permlink, ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), permlink}));
     BOOST_CHECK_EQUAL(success(), vote_brucelee(123));
     auto _vote = mvo()("id",0)("message_id",1)("voter","brucelee")("count",1);   // TODO: time
     CHECK_MATCHING_OBJECT(post.get_vote(N(brucelee), 0), _vote);
@@ -581,14 +561,12 @@ BOOST_FIXTURE_TEST_CASE(set_curators_prcnt, golos_publication_tester) try {
     
     init();
 
-    auto ref_block_num = control->head_block_header().block_num();
-    auto create_msg = [&](optional<uint16_t> curators_prcnt = optional<uint16_t>(), mssgid message_id = {}){ 
+    auto create_msg = [&](optional<uint16_t> curators_prcnt = optional<uint16_t>(), mssgid message_id = {}){
         if (message_id == mssgid())
-            message_id = {N(brucelee), "permlink", ref_block_num};
+            message_id = {N(brucelee), "permlink"};
         return post.create_msg(
             message_id, 
-            {N(), "parentprmlnk", 0},
-            0,
+            {N(), "parentprmlnk"},
             {},
             5000,
             false,
@@ -607,22 +585,22 @@ BOOST_FIXTURE_TEST_CASE(set_curators_prcnt, golos_publication_tester) try {
     
     BOOST_TEST_MESSAGE("--- checking that curators percent was setted as default");
     BOOST_CHECK_EQUAL(success(), create_msg());
-    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink", ref_block_num})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(post.min_curators_prcnt)/elai_t(cfg::_100percent)).data()));
+    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(post.min_curators_prcnt)/elai_t(cfg::_100percent)).data()));
 
     BOOST_TEST_MESSAGE("--- checking that curators percent was setted correctly");
-    BOOST_CHECK_EQUAL(success(), create_msg(7100, {N(jackiechan), "permlink", ref_block_num}));
-    BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "permlink", ref_block_num})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(7100)/elai_t(cfg::_100percent)).data()));
+    BOOST_CHECK_EQUAL(success(), create_msg(7100, {N(jackiechan), "permlink"}));
+    BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "permlink"})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(7100)/elai_t(cfg::_100percent)).data()));
 
     BOOST_TEST_MESSAGE("--- checking that curators percent was changed");
-    BOOST_CHECK_EQUAL(success(), post.set_curators_prcnt({N(brucelee), "permlink", ref_block_num}, 7300));
-    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink", ref_block_num})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(7300)/elai_t(cfg::_100percent)).data()));
+    BOOST_CHECK_EQUAL(success(), post.set_curators_prcnt({N(brucelee), "permlink"}, 7300));
+    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(7300)/elai_t(cfg::_100percent)).data()));
     
     BOOST_TEST_MESSAGE("--- checking that curators percent can't be changed");
     BOOST_CHECK_EQUAL(success(), token.issue(cfg::emission_name, N(jackiechan), token.make_asset(500), "issue tokens jackiechan"));
     BOOST_CHECK_EQUAL(success(), token.transfer(N(jackiechan), cfg::vesting_name, token.make_asset(100), "buy vesting"));
-    BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), {N(brucelee), "permlink", ref_block_num}, 123));
-    BOOST_CHECK_EQUAL(err.no_cur_percent, post.set_curators_prcnt({N(brucelee), "permlink", ref_block_num}, 7500));
-    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink", ref_block_num})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(7300)/elai_t(cfg::_100percent)).data()));
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), {N(brucelee), "permlink"}, 123));
+    BOOST_CHECK_EQUAL(err.no_cur_percent, post.set_curators_prcnt({N(brucelee), "permlink"}, 7500));
+    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"})["curators_prcnt"].as<base_t>(), static_cast<base_t>(elaf_t(elai_t(7300)/elai_t(cfg::_100percent)).data()));
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/golos.referral_tests.cpp
+++ b/tests/golos.referral_tests.cpp
@@ -239,21 +239,20 @@ BOOST_FIXTURE_TEST_CASE(create_referral_message_tests, golos_referral_tester) tr
     init_params_posts();
 
     const auto expire = 8; // sec
-    const auto ref_block_num = control->head_block_header().block_num();
     const auto current_time = control->head_block_time().sec_since_epoch();
     BOOST_CHECK_EQUAL(success(), referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(50)));
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(sania), "permlink", ref_block_num}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(sania), "permlink"}));
 
-    auto post_sania = post.get_message({N(sania), "permlink", ref_block_num});
+    auto post_sania = post.get_message({N(sania), "permlink"});
     BOOST_CHECK_EQUAL (post_sania["beneficiaries"].size(), 1);
     BOOST_CHECK_EQUAL( post_sania["beneficiaries"][uint8_t(0)].as<beneficiary>().account, N(issuer) );
 
     BOOST_CHECK_EQUAL(success(), referral.create_referral(N(issuer), N(pasha), 5000, current_time + expire, token.make_asset(50)));
-    BOOST_CHECK_EQUAL(err.limit_percents, post.create_msg({N(pasha), "permlink", ref_block_num}, {N(), "parentprmlnk", 0}, 0, { beneficiary{N(tania), 7000} }));
-    BOOST_CHECK_EQUAL(err.referrer_benif, post.create_msg({N(pasha), "permlink", ref_block_num}, {N(), "parentprmlnk", 0}, 0, { beneficiary{N(issuer), 2000} }));
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(pasha), "permlink", ref_block_num}, {N(), "parentprmlnk", 0}, 0, { beneficiary{N(tania), 2000} }));
+    BOOST_CHECK_EQUAL(err.limit_percents, post.create_msg({N(pasha), "permlink"}, {N(), "parentprmlnk"}, { beneficiary{N(tania), 7000} }));
+    BOOST_CHECK_EQUAL(err.referrer_benif, post.create_msg({N(pasha), "permlink"}, {N(), "parentprmlnk"}, { beneficiary{N(issuer), 2000} }));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(pasha), "permlink"}, {N(), "parentprmlnk"}, { beneficiary{N(tania), 2000} }));
 
-    auto post_pasha = post.get_message({N(pasha), "permlink", ref_block_num});
+    auto post_pasha = post.get_message({N(pasha), "permlink"});
     BOOST_CHECK_EQUAL (post_pasha["beneficiaries"].size(), 2);
 } FC_LOG_AND_RETHROW()
 

--- a/tests/golos.social_tests.cpp
+++ b/tests/golos.social_tests.cpp
@@ -174,14 +174,12 @@ BOOST_FIXTURE_TEST_CASE(golos_blocked_commenting_test, golos_social_tester) try 
     init(bignum, 10);
 
     BOOST_TEST_MESSAGE("--- create post: dave");
-    auto ref_block_num_dave = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"dave"_n, "permlink", ref_block_num_dave}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"dave"_n, "permlink"}));
     produce_block();
 
     BOOST_TEST_MESSAGE("--- create comment: erin to dave");
-    auto ref_block_num_erin = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, "permlink2", ref_block_num_erin},
-                                                 {"dave"_n, "permlink", ref_block_num_dave}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, "permlink2"},
+                                                 {"dave"_n, "permlink"}));
     produce_block();
 
     BOOST_TEST_MESSAGE("--- block: dave erin");
@@ -189,9 +187,8 @@ BOOST_FIXTURE_TEST_CASE(golos_blocked_commenting_test, golos_social_tester) try 
     produce_block();
 
     BOOST_TEST_MESSAGE("--- create comment: erin to dave again (fail)");
-    auto ref_block_num_erin1 = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(err.you_are_blocked, post.create_msg({"erin"_n, "permlink3", ref_block_num_erin1},
-                                                           {"dave"_n, "permlink", ref_block_num_dave}));
+    BOOST_CHECK_EQUAL(err.you_are_blocked, post.create_msg({"erin"_n, "permlink3"},
+                                                           {"dave"_n, "permlink"}));
     produce_block();
 } FC_LOG_AND_RETHROW()
 
@@ -217,11 +214,10 @@ BOOST_FIXTURE_TEST_CASE(golos_reputation_test, golos_social_tester) try {
 
     BOOST_TEST_MESSAGE("--- upvote: dave erin 1000");
     new_permlink();
-    auto ref_block_num_erin = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, permlink, ref_block_num_erin}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, permlink}));
     BOOST_CHECK_EQUAL(success(), social.create_reput({"erin"_n}));
     BOOST_CHECK_EQUAL(success(), social.create_reput({"dave"_n}));
-    BOOST_CHECK_EQUAL(success(), post.upvote("dave"_n, {"erin"_n, permlink, ref_block_num_erin}, 1000));
+    BOOST_CHECK_EQUAL(success(), post.upvote("dave"_n, {"erin"_n, permlink}, 1000));
     produce_block();
 
     auto erin_rep = social.get_reputation("erin"_n);
@@ -230,16 +226,14 @@ BOOST_FIXTURE_TEST_CASE(golos_reputation_test, golos_social_tester) try {
 
     BOOST_TEST_MESSAGE("--- downvote: erin dave 200");
     new_permlink();
-    auto ref_block_num_dave = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"dave"_n, permlink, ref_block_num_dave}));
-    BOOST_CHECK_EQUAL(success(), post.downvote("erin"_n, {"dave"_n, permlink, ref_block_num_dave}, 200));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"dave"_n, permlink}));
+    BOOST_CHECK_EQUAL(success(), post.downvote("erin"_n, {"dave"_n, permlink}, 200));
     produce_block();
 
     BOOST_TEST_MESSAGE("--- downvote: dave erin 200 (check rule #1)");
     new_permlink();
-    auto ref_block_num_erin1 = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, permlink, ref_block_num_erin1}));
-    BOOST_CHECK_EQUAL(success(), post.downvote("dave"_n, {"erin"_n, permlink, ref_block_num_erin1}, 10));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, permlink}));
+    BOOST_CHECK_EQUAL(success(), post.downvote("dave"_n, {"erin"_n, permlink}, 10));
     produce_block();
 
     auto new_erin_rep = social.get_reputation("erin"_n);
@@ -247,16 +241,14 @@ BOOST_FIXTURE_TEST_CASE(golos_reputation_test, golos_social_tester) try {
 
     BOOST_TEST_MESSAGE("--- upvote: erin dave 100");
     new_permlink();
-    auto ref_block_num_dave1 = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"dave"_n, permlink, ref_block_num_dave1}));
-    BOOST_CHECK_EQUAL(success(), post.upvote("erin"_n, {"dave"_n, permlink, ref_block_num_dave1}, 100));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"dave"_n, permlink}));
+    BOOST_CHECK_EQUAL(success(), post.upvote("erin"_n, {"dave"_n, permlink}, 100));
     produce_block();
 
     BOOST_TEST_MESSAGE("--- downvote: dave erin 200 (check rule #2)");
     new_permlink();
-    auto ref_block_num_erin2 = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, permlink, ref_block_num_erin2}));
-    BOOST_CHECK_EQUAL(success(), post.downvote("dave"_n, {"erin"_n, permlink, ref_block_num_erin2}, 10));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, permlink}));
+    BOOST_CHECK_EQUAL(success(), post.downvote("dave"_n, {"erin"_n, permlink}, 10));
     produce_block();
 
     auto new_erin_rep2 = social.get_reputation("erin"_n);
@@ -264,16 +256,14 @@ BOOST_FIXTURE_TEST_CASE(golos_reputation_test, golos_social_tester) try {
 
     BOOST_TEST_MESSAGE("--- upvote: erin dave 100");
     new_permlink();
-    auto ref_block_num_dave2 = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"dave"_n, permlink, ref_block_num_dave2}));
-    BOOST_CHECK_EQUAL(success(), post.upvote("erin"_n, {"dave"_n, permlink, ref_block_num_dave2}, 10000));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"dave"_n, permlink}));
+    BOOST_CHECK_EQUAL(success(), post.upvote("erin"_n, {"dave"_n, permlink}, 10000));
     produce_block();
 
     BOOST_TEST_MESSAGE("--- downvote: dave erin 200 (conforming rules)");
     new_permlink();
-    auto ref_block_num_erin3 = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, permlink, ref_block_num_erin3}));
-    BOOST_CHECK_EQUAL(success(), post.downvote("dave"_n, {"erin"_n, permlink, ref_block_num_erin3}, 10));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, permlink}));
+    BOOST_CHECK_EQUAL(success(), post.downvote("dave"_n, {"erin"_n, permlink}, 10));
     produce_block();
 
     auto new_erin_rep3 = social.get_reputation("erin"_n);
@@ -316,10 +306,9 @@ BOOST_FIXTURE_TEST_CASE(delete_reputation, golos_social_tester) try {
     init(1000000, 10);
 
     BOOST_TEST_MESSAGE("--- checking that reputation was added");
-    auto ref_block_num_erin = control->head_block_header().block_num();
-    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, "permlink", ref_block_num_erin}));
+    BOOST_CHECK_EQUAL(success(), post.create_msg({"erin"_n, "permlink"}));
     BOOST_CHECK_EQUAL(success(), social.create_reput({"erin"_n}));
-    BOOST_CHECK_EQUAL(success(), post.upvote("dave"_n, {"erin"_n, "permlink", ref_block_num_erin}, 1000));
+    BOOST_CHECK_EQUAL(success(), post.upvote("dave"_n, {"erin"_n, "permlink"}, 1000));
     produce_block();
     auto erin_rep = social.get_reputation("erin"_n);
     BOOST_CHECK(!erin_rep.is_null());


### PR DESCRIPTION
Resolve #622.

Message identifier contains only two fields: `author/permlink`.
Depend on `ref_block_num` is removed.

To support comment and update old posts and comments the new table `permlink` is added.
RAM payer for records is the publication contract.

That is impossible to remove permlink from archive, if message doesn't exist.
It so, because permlink in archive (to minimize RAM usage), it can't be edit, but for removing the field `childcount` is required.

