### PR TITLE
Improve posting tests model and timepenalty_test #634

### DIFF
--- a/tests/golos.publication_rewards_types.hpp
+++ b/tests/golos.publication_rewards_types.hpp
@@ -34,8 +34,8 @@ struct message_data {
 };
 
 constexpr struct {
-    balance_data balance {10.0, 20.0};
-    pool_data pool {0.001, 15, -0.01, -0.01};
+    balance_data balance {0.01, 0.02};            // this values are divided to PRECISION_DIV, scale if change
+    pool_data pool {0.001, 0.015, -0.01, -0.01};  // 0.015 value is divided to PRECISION_DIV (=15 if PRECISION_DIV=1.0)
     message_data message {-0.01, -0.01, -0.01};
 } delta;
 
@@ -232,8 +232,8 @@ struct limits {
     enum kind_t: enum_t {POST, COMM, VOTE, POSTBW, UNDEF};
     std::vector<func_t> restorers; //(funcs of: prev_charge (p), vesting (v), elapsed_seconds (t))
     std::vector<limitedact> limitedacts;
-    std::vector<int64_t> vestingprices;//disabled if < 0
-    std::vector<int64_t> minvestings;
+    std::vector<double> vestingprices;//disabled if < 0
+    std::vector<double> minvestings;
 
     const limitedact& get_limited_act(kind_t kind) const {
         return limitedacts.at(static_cast<size_t>(kind));

--- a/tests/golos_tester.hpp
+++ b/tests/golos_tester.hpp
@@ -49,7 +49,10 @@ protected:
     std::map<account_name, abi_serializer> _abis;
 
 public:
-    golos_tester(name code): tester(), _code(code), _chaindb(control->chaindb()) {
+    golos_tester(name code)
+    : tester(base_tester::default_config("_GOLOSTEST_"))
+    , _code(code)
+    , _chaindb(control->chaindb()) {
     }
     ~golos_tester() {
     }


### PR DESCRIPTION
Resolves #634, which may be considered wrong issue. There was no error in calculations, but poor tests output. This PR makes output clearer and adds support of assets with non-zero precisions to reward_calcs model.

* Update reward_calcs model to work with nonzero precision
* Make timepenalty_test more precise + own db sys name for tests
    1. Use own system name for tests  in mondo db
    2. Update `timepenalty_test` to use correct timing
    3. Update `pay_rewards_in_state` closing time
    4. More clear info about model and actual state

