### PR TITLE
Update genesis-info tpl to support permissions & auth links #645

### DIFF
--- a/genesis/genesis-info.json.tmpl
+++ b/genesis/genesis-info.json.tmpl
@@ -82,35 +82,102 @@
 #        },
         {"name": "cyber.worker",  "owner_key": "INITIAL",   "active_key": "INITIAL"},
 
-        {"name": "gls.issuer",    "owner_key": "INITIAL",   "active_key": "INITIAL"},
-        {"name": "gls.ctrl",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+        {"name": "gls.issuer",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL", "accounts": ["gls.ctrl@cyber.code", "gls.emit@cyber.code"]},
+                {"name": "issue", "key": "GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62"},
+                {"name": "witn.smajor", "key": "INITIAL"},
+                {"name": "witn.major", "key": "INITIAL"},
+                {"name": "witn.minor", "key": "INITIAL"}
+            ]
+        },
+        {"name": "gls.ctrl",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL", "accounts": ["@cyber.code"]}
+            ],
             "abi": {"path": "$GOLOS_CONTRACTS/golos.ctrl/golos.ctrl.abi", "hash":""},
             "code": {"path": "$GOLOS_CONTRACTS/golos.ctrl/golos.ctrl.wasm", "hash":""}
         },
-        {"name": "gls.emit",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+        {"name": "gls.emit",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL", "accounts": ["@cyber.code"]}
+            ],
             "abi": {"path": "$GOLOS_CONTRACTS/golos.emit/golos.emit.abi", "hash":""},
             "code": {"path": "$GOLOS_CONTRACTS/golos.emit/golos.emit.wasm", "hash":""}
         },
-        {"name": "gls.vesting",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+        {"name": "gls.vesting",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL", "accounts": ["@cyber.code"]}
+            ],
             "abi": {"path": "$GOLOS_CONTRACTS/golos.vesting/golos.vesting.abi", "hash":""},
             "code": {"path": "$GOLOS_CONTRACTS/golos.vesting/golos.vesting.wasm", "hash":""}
         },
-        {"name": "gls.publish",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+        {"name": "gls.publish",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL", "accounts": ["@cyber.code"]}
+            ],
             "abi": {"path": "$GOLOS_CONTRACTS/golos.publication/golos.publication.abi", "hash":""},
             "code": {"path": "$GOLOS_CONTRACTS/golos.publication/golos.publication.wasm", "hash":""}
         },
-        {"name": "gls.social",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+        {"name": "gls.social",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL", "accounts": ["gls.publish@cyber.code"]}
+            ],
             "abi": {"path": "$GOLOS_CONTRACTS/golos.social/golos.social.abi", "hash":""},
             "code": {"path": "$GOLOS_CONTRACTS/golos.social/golos.social.wasm", "hash":""}
         },
-        {"name": "gls.charge",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+        {"name": "gls.charge",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL"}
+            ],
             "abi": {"path": "$GOLOS_CONTRACTS/golos.charge/golos.charge.abi", "hash":""},
             "code": {"path": "$GOLOS_CONTRACTS/golos.charge/golos.charge.wasm", "hash":""}
         },
-        {"name": "gls.referral",      "owner_key": "INITIAL",   "active_key": "INITIAL",
+        {"name": "gls.referral",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL"}
+            ],
             "abi": {"path": "$GOLOS_CONTRACTS/golos.referral/golos.referral.abi", "hash":""},
             "code": {"path": "$GOLOS_CONTRACTS/golos.referral/golos.referral.wasm", "hash":""}
         },
-        {"name": "gls.worker",        "owner_key": "INITIAL",   "active_key": "INITIAL"}
-    ]
+        {"name": "gls.worker",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL"}
+            ]
+        }
+    ],
+    "auth_links": [
+        {
+            "permission": "cyber@createuser",
+            "links": ["cyber:newaccount", "cyber.token:open", "gls.vesting:open"]
+        },{
+            "permission": "gls.issuer@issue",
+            "links": ["cyber.token:issue", "cyber.token:transfer"]
+        }
+    ],
+    "golos": {
+        "domain": "golos",
+        "names": {
+            "issuer": "gls.issuer",
+            "control": "gls.ctrl",
+            "vesting": "gls.vesting",
+            "posting": "gls.publish",
+            "social": "gls.social",
+            "charge": "gls.charge"
+        },
+        "recovery": {
+            "wait_days": 30
+        },
+        "max_supply": 1000000000,
+        "sys_max_supply": 1000000000
+    }
 }

--- a/golos.social/golos.social.cpp
+++ b/golos.social/golos.social.cpp
@@ -123,7 +123,7 @@ void social::changereput(name voter, name author, int64_t rshares) {
         return;
     }
 
-    // Rule #2: If you are downvoяting another user, you must have more reputation than him
+    // Rule #2: If you are downvoting another user, you must have more reputation than him
     if (rshares < 0 && voter_rep.reputation <= author_rep.reputation) {
         return;
     }

--- a/scripts/golos-boot-sequence/golos-boot-sequence.py
+++ b/scripts/golos-boot-sequence/golos-boot-sequence.py
@@ -222,7 +222,27 @@ def createGolosAccounts():
     for acc in golosAccounts:
         if not (args.golos_genesis and acc.inGenesis):
             createAccount('cyber', acc.name, args.public_key)
+
+    if not args.golos_genesis:
+        updateAuth('gls.issuer',  'witn.major', 'active', [args.public_key], [])
+        updateAuth('gls.issuer',  'witn.minor', 'active', [args.public_key], [])
+        updateAuth('gls.issuer',  'witn.smajor', 'active', [args.public_key], [])
+        updateAuth('gls.issuer',  'active', 'owner', [args.public_key], ['gls.ctrl@cyber.code', 'gls.emit@cyber.code'])
+        updateAuth('gls.ctrl',    'active', 'owner', [args.public_key], ['gls.ctrl@cyber.code'])
+        updateAuth('gls.publish', 'active', 'owner', [args.public_key], ['gls.publish@cyber.code'])
+        updateAuth('gls.vesting', 'active', 'owner', [args.public_key], ['gls.vesting@cyber.code'])
+        updateAuth('gls.social',  'active', 'owner', [args.public_key], ['gls.publish@cyber.code'])
+        updateAuth('gls.emit',    'active', 'owner', [args.public_key], ['gls.emit@cyber.code'])
+
     updateAuth('cyber',       'createuser', 'active', ['GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62'], [])
+    if not args.golos_genesis:
+        linkAuth('cyber', 'cyber', 'newaccount', 'createuser')
+        linkAuth('cyber', 'gls.vesting', 'open', 'createuser')
+        linkAuth('cyber', 'cyber.token', 'open', 'createuser')
+
+        updateAuth('gls.issuer',  'issue', 'active', ['GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62'], [])
+        linkAuth('gls.issuer', 'cyber.token', 'issue', 'issue')
+        linkAuth('gls.issuer', 'cyber.token', 'transfer', 'issue')
 
 def stepInstallContracts():
     for acc in golosAccounts:

--- a/scripts/golos-boot-sequence/golos-boot-sequence.py
+++ b/scripts/golos-boot-sequence/golos-boot-sequence.py
@@ -222,24 +222,7 @@ def createGolosAccounts():
     for acc in golosAccounts:
         if not (args.golos_genesis and acc.inGenesis):
             createAccount('cyber', acc.name, args.public_key)
-    updateAuth('gls.issuer',  'witn.major', 'active', [args.public_key], [])
-    updateAuth('gls.issuer',  'witn.minor', 'active', [args.public_key], [])
-    updateAuth('gls.issuer',  'witn.smajor', 'active', [args.public_key], [])
-    updateAuth('gls.issuer',  'active', 'owner', [args.public_key], ['gls.ctrl@cyber.code', 'gls.emit@cyber.code'])
-    updateAuth('gls.ctrl',    'active', 'owner', [args.public_key], ['gls.ctrl@cyber.code'])
-    updateAuth('gls.publish', 'active', 'owner', [args.public_key], ['gls.publish@cyber.code'])
-    updateAuth('gls.vesting', 'active', 'owner', [args.public_key], ['gls.vesting@cyber.code'])
-    updateAuth('gls.social',  'active', 'owner', [args.public_key], ['gls.publish@cyber.code'])
-    updateAuth('gls.emit',    'active', 'owner', [args.public_key], ['gls.emit@cyber.code'])
-
     updateAuth('cyber',       'createuser', 'active', ['GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62'], [])
-    linkAuth('cyber', 'cyber', 'newaccount', 'createuser')
-    linkAuth('cyber', 'gls.vesting', 'open', 'createuser')
-    linkAuth('cyber', 'cyber.token', 'open', 'createuser')
-
-    updateAuth('gls.issuer',  'issue', 'active', ['GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62'], [])
-    linkAuth('gls.issuer', 'cyber.token', 'issue', 'issue')
-    linkAuth('gls.issuer', 'cyber.token', 'transfer', 'issue')
 
 def stepInstallContracts():
     for acc in golosAccounts:

--- a/tests/golos.publication_rewards_tests.cpp
+++ b/tests/golos.publication_rewards_tests.cpp
@@ -1,4 +1,4 @@
-#define SHOW_ENABLE
+//#define SHOW_ENABLE
 #include "golos.publication_rewards_types.hpp"
 #include "golos_tester.hpp"
 #include "golos.posting_test_api.hpp"


### PR DESCRIPTION
+ additional permissions (except `cyber.createuser`) and auth links moved to genesis-info.json from golos-boot-sequence
+ also disables detailed logging in rewards tests.