### PR TITLE
Use gls as issuer and update genesis tpl #655,#656

### DIFF
--- a/genesis/genesis-info.json.tmpl
+++ b/genesis/genesis-info.json.tmpl
@@ -56,37 +56,52 @@
         }
     },
     "accounts": [
-#        {"name": "cyber",         "owner_key": "INITIAL",   "active_key": "INITIAL",
-#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.bios/cyber.bios.abi", "hash":""},
-#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.bios/cyber.bios.wasm", "hash":""}
-#        },
-#        {"name": "cyber.domain",  "owner_key": "INITIAL",   "active_key": "INITIAL",
-#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.domain/cyber.domain.abi", "hash":""},
-#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.domain/cyber.domain.wasm", "hash":""}
-#        },
-        {"name": "cyber.token",   "owner_key": "INITIAL",   "active_key": "INITIAL",
+        {"name": "cyber",
+            "update": true,
+            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.bios/cyber.bios.abi", "hash":""},
+            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.bios/cyber.bios.wasm", "hash":""}
+        },
+        {"name": "cyber.domain",
+            "update": true,
+            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.domain/cyber.domain.abi", "hash":""},
+            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.domain/cyber.domain.wasm", "hash":""}
+        },
+        {"name": "cyber.msig",
+            "update": true,
+            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.msig/cyber.msig.abi", "hash":""},
+            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.msig/cyber.msig.wasm", "hash":""}
+        },
+        {"name": "cyber.govern",
+            "update": true,
+            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.govern/cyber.govern.abi", "hash":""},
+            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.govern/cyber.govern.wasm", "hash":""}
+        },
+        {"name": "cyber.stake",
+            "update": true,
+            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.stake/cyber.stake.abi", "hash":""},
+            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.stake/cyber.stake.wasm", "hash":""}
+        },
+        {"name": "cyber.token",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL"}
+            ],
             "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.token/cyber.token.abi", "hash":""},
             "code": {"path": "$CYBERWAY_CONTRACTS/cyber.token/cyber.token.wasm", "hash":""}
         },
-#        {"name": "cyber.msig",   "owner_key": "INITIAL",   "active_key": "INITIAL",
-#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.msig/cyber.msig.abi", "hash":""},
-#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.msig/cyber.msig.wasm", "hash":""}
-#        },
-#        {"name": "cyber.govern",   "owner_key": "INITIAL",   "active_key": "INITIAL",
-#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.govern/cyber.govern.abi", "hash":""},
-#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.govern/cyber.govern.wasm", "hash":""}
-#        },
-#        {"name": "cyber.stake",   "owner_key": "INITIAL",   "active_key": "INITIAL",
-#            "abi":  {"path": "$CYBERWAY_CONTRACTS/cyber.stake/cyber.stake.abi", "hash":""},
-#            "code": {"path": "$CYBERWAY_CONTRACTS/cyber.stake/cyber.stake.wasm", "hash":""}
-#        },
-        {"name": "cyber.worker",  "owner_key": "INITIAL",   "active_key": "INITIAL"},
+        {"name": "cyber.worker",
+            "permissions": [
+                {"name": "owner", "key": "INITIAL"},
+                {"name": "active", "key": "INITIAL"}
+            ]
+        },
 
-        {"name": "gls.issuer",
+        {"name": "gls",
             "permissions": [
                 {"name": "owner", "key": "INITIAL"},
                 {"name": "active", "key": "INITIAL", "accounts": ["gls.ctrl@cyber.code", "gls.emit@cyber.code"]},
                 {"name": "issue", "key": "GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62"},
+                {"name": "createuser", "key": "GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62"},
                 {"name": "witn.smajor", "key": "INITIAL"},
                 {"name": "witn.major", "key": "INITIAL"},
                 {"name": "witn.minor", "key": "INITIAL"}
@@ -157,17 +172,17 @@
     ],
     "auth_links": [
         {
-            "permission": "cyber@createuser",
-            "links": ["cyber:newaccount", "cyber.token:open", "gls.vesting:open"]
+            "permission": "gls@createuser",
+            "links": ["cyber:newaccount", "cyber.domain:newusername", "cyber.token:open", "gls.vesting:open"]
         },{
-            "permission": "gls.issuer@issue",
+            "permission": "gls@issue",
             "links": ["cyber.token:issue", "cyber.token:transfer"]
         }
     ],
     "golos": {
         "domain": "golos",
         "names": {
-            "issuer": "gls.issuer",
+            "issuer": "gls",
             "control": "gls.ctrl",
             "vesting": "gls.vesting",
             "posting": "gls.publish",

--- a/golos.vesting/golos.vesting.cpp
+++ b/golos.vesting/golos.vesting.cpp
@@ -332,7 +332,7 @@ void vesting::timeoutconv() {
                 auto converted = vesting_to_token(to_send, vesting, -correction);   // TODO: get_balance can throw #549
                 vestings.modify(vesting, name(), [&](auto& v) {
                     v.supply -= to_send;
-                    send_stat_event(v);                    
+                    send_stat_event(v);
                 });
                 // TODO: payment action #549
                 INLINE_ACTION_SENDER(token, transfer)(config::token_name, {_self, config::active_name},
@@ -357,7 +357,7 @@ void vesting::timeoutrdel() {
         eosio_assert(balance_recipient != account_recipient.end(), "This token is not on the sender balance sheet");
         account_recipient.modify(balance_recipient, name(), [&](auto &item){
             item.delegated -= obj->quantity;
-            send_account_event(obj->delegator, item);                    
+            send_account_event(obj->delegator, item);
         });
         obj = index.erase(obj);
     }

--- a/scripts/golos-boot-sequence/golos-boot-sequence.py
+++ b/scripts/golos-boot-sequence/golos-boot-sequence.py
@@ -23,7 +23,7 @@ unlockTimeout = 999999999
 
 _golosAccounts = [
     # name           inGenesis    contract
-    ('gls.issuer',   True,       None),
+    ('gls',          True,       None),
     ('gls.ctrl',     True,       'golos.ctrl'),
     ('gls.emit',     True,       'golos.emit'),
     ('gls.vesting',  True,       'golos.vesting'),
@@ -149,7 +149,7 @@ def openTokenBalance(account):
         jsonArg([account, args.token, account]) + '-p %s'%account)
 
 def issueToken(account, amount):
-    retry(args.cleos + 'push action cyber.token issue ' + jsonArg([account, amount, "memo"]) + ' -p gls.issuer')
+    retry(args.cleos + 'push action cyber.token issue ' + jsonArg([account, amount, "memo"]) + ' -p gls')
 
 def buyVesting(account, amount):
     issueToken(account, amount)
@@ -224,25 +224,25 @@ def createGolosAccounts():
             createAccount('cyber', acc.name, args.public_key)
 
     if not args.golos_genesis:
-        updateAuth('gls.issuer',  'witn.major', 'active', [args.public_key], [])
-        updateAuth('gls.issuer',  'witn.minor', 'active', [args.public_key], [])
-        updateAuth('gls.issuer',  'witn.smajor', 'active', [args.public_key], [])
-        updateAuth('gls.issuer',  'active', 'owner', [args.public_key], ['gls.ctrl@cyber.code', 'gls.emit@cyber.code'])
+        updateAuth('gls',  'witn.major', 'active', [args.public_key], [])
+        updateAuth('gls',  'witn.minor', 'active', [args.public_key], [])
+        updateAuth('gls',  'witn.smajor', 'active', [args.public_key], [])
+        updateAuth('gls',  'active', 'owner', [args.public_key], ['gls.ctrl@cyber.code', 'gls.emit@cyber.code'])
         updateAuth('gls.ctrl',    'active', 'owner', [args.public_key], ['gls.ctrl@cyber.code'])
         updateAuth('gls.publish', 'active', 'owner', [args.public_key], ['gls.publish@cyber.code'])
         updateAuth('gls.vesting', 'active', 'owner', [args.public_key], ['gls.vesting@cyber.code'])
         updateAuth('gls.social',  'active', 'owner', [args.public_key], ['gls.publish@cyber.code'])
         updateAuth('gls.emit',    'active', 'owner', [args.public_key], ['gls.emit@cyber.code'])
 
-    updateAuth('cyber',       'createuser', 'active', ['GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62'], [])
-    if not args.golos_genesis:
-        linkAuth('cyber', 'cyber', 'newaccount', 'createuser')
-        linkAuth('cyber', 'gls.vesting', 'open', 'createuser')
-        linkAuth('cyber', 'cyber.token', 'open', 'createuser')
+        updateAuth('gls', 'createuser', 'active', ['GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62'], [])
+        linkAuth('gls', 'cyber', 'newaccount', 'createuser')
+        linkAuth('gls', 'cyber.domain', 'newusername', 'createuser')
+        linkAuth('gls', 'gls.vesting', 'open', 'createuser')
+        linkAuth('gls', 'cyber.token', 'open', 'createuser')
 
-        updateAuth('gls.issuer',  'issue', 'active', ['GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62'], [])
-        linkAuth('gls.issuer', 'cyber.token', 'issue', 'issue')
-        linkAuth('gls.issuer', 'cyber.token', 'transfer', 'issue')
+        updateAuth('gls',  'issue', 'active', ['GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62'], [])
+        linkAuth('gls', 'cyber.token', 'issue', 'issue')
+        linkAuth('gls', 'cyber.token', 'transfer', 'issue')
 
 def stepInstallContracts():
     for acc in golosAccounts:
@@ -251,12 +251,12 @@ def stepInstallContracts():
 
 def stepCreateTokens():
     if not args.golos_genesis:
-        retry(args.cleos + 'push action cyber.token create ' + jsonArg(["gls.issuer", intToToken(10000000000*10000)]) + ' -p cyber.token')
+        retry(args.cleos + 'push action cyber.token create ' + jsonArg(["gls", intToToken(10000000000*10000)]) + ' -p cyber.token')
     #totalAllocation = allocateFunds(0, len(accounts))
     #totalAllocation = 10000000*10000
     #retry(args.cleos + 'push action cyber.token issue ' + jsonArg(["gls.publish", intToToken(totalAllocation), "memo"]) + ' -p gls.publish')
     if not args.golos_genesis:
-        retry(args.cleos + 'push action gls.vesting create ' + jsonArg([args.vesting, 'gls.ctrl']) + '-p gls.issuer')
+        retry(args.cleos + 'push action gls.vesting create ' + jsonArg([args.vesting, 'gls.ctrl']) + '-p gls')
     for acc in golosAccounts:
         openTokenBalance(acc.name)
     sleep(1)
@@ -300,14 +300,14 @@ def createCommunity():
                 'max_interest':0,
                 'return_time':120
             }]
-        ]]) + '-p gls.issuer')
+        ]]) + '-p gls')
     retry(args.cleos + 'push action gls.ctrl setparams ' + jsonArg([
         [
             ['ctrl_token',{
                 'code':args.symbol
             }],
             ['multisig_acc',{
-                'name':'gls.issuer'
+                'name':'gls'
             }],
             ['max_witnesses',{
                 'max':5

--- a/scripts/testnet.py
+++ b/scripts/testnet.py
@@ -92,7 +92,7 @@ def openTokenBalance(account):
     pushAction('cyber.token', 'open', account, [account, args.token, account])
 
 def issueToken(account, amount, memo=""):
-    pushAction('cyber.token', 'issue', 'gls.issuer', [account, amount, memo])
+    pushAction('cyber.token', 'issue', 'gls', [account, amount, memo])
 
 def buyVesting(account, amount):
     issueToken(account, amount)


### PR DESCRIPTION
also fixes missing permissions for cyber.x account in genesis-info tpl.

Note: `createuser` permission moved from `cyber` to `gls`. Any account can create 12-symbol account, there is no need to give such permission to `cyber`. Also `cyber.domain:newusername` action added to this permission to assign usernames in `gls` scope