### PR TITLE
Add checking on user exist on open vesting account. #698

### DIFF
--- a/golos.vesting/golos.vesting.cpp
+++ b/golos.vesting/golos.vesting.cpp
@@ -408,6 +408,7 @@ void vesting::timeoutrdel() {
 
 void vesting::open(name owner, symbol symbol, name ram_payer) {
     require_auth(ram_payer);
+    eosio_assert(is_account(owner), "owner account does not exist");
     vesting_table stat(_self, _self.value);
     auto token_stat = stat.require_find(symbol.code().raw(), "not found token vesting");
     eosio_assert(token_stat->supply.symbol.precision() == symbol.precision(), "mismatch of accuracy of vesting");

--- a/tests/golos.vesting_tests.cpp
+++ b/tests/golos.vesting_tests.cpp
@@ -100,6 +100,7 @@ protected:
         const string cutoff = amsg("can't delegate, not enough power");
         const string not_found_token_vesting = amsg("not found token vesting");
         const string mismatch_of_accuracy = amsg("mismatch of accuracy of vesting");
+        const string owner_not_exists = amsg("owner account does not exist");
     } err;
 
     const uint8_t withdraw_intervals = 13;
@@ -203,6 +204,8 @@ BOOST_FIXTURE_TEST_CASE(create_vesting, golos_vesting_tester) try {
     BOOST_CHECK_EQUAL(success(), vest.create_vesting(issuer));
 
     BOOST_CHECK_EQUAL(err.mismatch_of_accuracy, vest.open(N(sania), _vesting_sym_e, N(sania)));
+    BOOST_CHECK_EQUAL(err.owner_not_exists, vest.open(N(denlarimer), _vesting_sym_e, N(sania)));
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(buy_vesting, golos_vesting_tester) try {


### PR DESCRIPTION
Resolve #698: add checking on account exist on open vesting account.

Additional changes: update cyberway.contracts with:
- checking on account exist on open token account.
- increase memo size in token methods
- update cyber.stake tests after changes in cyberway storage usage calculation

