### PR TITLE
Fix vesting withdraw: erase objects with too low amount #706

### DIFF
--- a/golos.vesting/golos.vesting.cpp
+++ b/golos.vesting/golos.vesting.cpp
@@ -326,7 +326,7 @@ void vesting::create(symbol symbol, name notify_acc) {
 
 void vesting::timeoutconv() {
     require_auth(_self);
-    const int max_steps = 16;           // TODO: configurable #707
+    int max_steps = 16;           // TODO: configurable #707
     const auto memo = "withdraw";
     const auto now = time_point_sec(::now());
     vesting_table vestings(_self, _self.value);


### PR DESCRIPTION
+ also adds limit to max number of withdrawals per call (helps with genesis withdraw)