### PR TITLE
Remove possible asserts from timeoutconv #549

### DIFF
--- a/genesis/genesis-info.json.tmpl
+++ b/genesis/genesis-info.json.tmpl
@@ -277,7 +277,7 @@
             "links": ["gls.emit:emit"]
         },{
             "permission": "gls.vesting@code",
-            "links": ["cyber.token:transfer", "gls.vesting:timeout", "gls.vesting:timeoutconv", "gls.vesting:timeoutrdel"]
+            "links": ["cyber.token:transfer", "cyber.token:payment", "gls.vesting:timeout", "gls.vesting:timeoutconv", "gls.vesting:timeoutrdel"]
         },{
             "permission": "gls.publish@code",
             "links": ["cyber.token:payment", "cyber.token:transfer", "gls.publish:closemssg", "gls.publish:paymssgrwrd"]

--- a/golos.vesting/golos.vesting.hpp
+++ b/golos.vesting/golos.vesting.hpp
@@ -22,8 +22,7 @@ public:
 
     [[eosio::action]] void withdraw(name from, name to, asset quantity);
     [[eosio::action]] void stopwithdraw(name owner, symbol type);
-    [[eosio::action]] void delegate(name delegator, name delegatee, asset quantity,
-        uint16_t interest_rate);
+    [[eosio::action]] void delegate(name delegator, name delegatee, asset quantity, uint16_t interest_rate);
     [[eosio::action]] void undelegate(name delegator, name delegatee, asset quantity);
 
     [[eosio::action]] void create(symbol symbol, name notify_acc);
@@ -36,7 +35,6 @@ public:
     [[eosio::action]] void timeoutrdel();
 
     void on_transfer(name from, name to, asset quantity, std::string memo);
-    void do_transfer_vesting(name from, name to, asset quantity, std::string memo);
     void on_bulk_transfer(name from, std::vector<token::recipient> recipients);
 
     // tables
@@ -181,6 +179,7 @@ public:
     }
 
 private:
+    void do_transfer_vesting(name from, name to, asset quantity, std::string memo);
     void notify_balance_change(name owner, asset diff);
     void sub_balance(name owner, asset value, bool retire_mode = false);
     void add_balance(name owner, asset value, name ram_payer);

--- a/scripts/golos-boot-sequence/golos-boot-sequence.py
+++ b/scripts/golos-boot-sequence/golos-boot-sequence.py
@@ -51,7 +51,7 @@ def fillGolosAccounts(golosAccounts):
         ('gls.vesting',  True,       'golos.vesting',
             [("owner",       [], ["gls@owner"], []),
              ("active",      [], ["gls@active"], []),
-             ("code",        [], ["gls.vesting@cyber.code"], ["cyber.token:transfer", "gls.vesting:timeout", "gls.vesting:timeoutconv", "gls.vesting:timeoutrdel"]),
+             ("code",        [], ["gls.vesting@cyber.code"], ["cyber.token:transfer", "cyber.token:payment", "gls.vesting:timeout", "gls.vesting:timeoutconv", "gls.vesting:timeoutrdel"]),
             ]),
         ('gls.publish',  True,       'golos.publication',
             [("owner",       [], ["gls@owner"], []),

--- a/tests/golos.vesting_test_api.hpp
+++ b/tests/golos.vesting_test_api.hpp
@@ -20,7 +20,7 @@ struct golos_vesting_api: base_contract_api {
         _tester->link_authority(_code, _code, cfg::code_name, N(timeout));
         _tester->link_authority(_code, _code, cfg::code_name, N(timeoutconv));
         _tester->link_authority(_code, _code, cfg::code_name, N(timeoutrdel));
-        _tester->link_authority(_code, token_name, cfg::code_name, N(transfer));
+        _tester->link_authority(_code, token_name, cfg::code_name, N(payment));
     }
 
     void add_changevest_auth_to_issuer(account_name issuer, account_name control) {
@@ -48,11 +48,11 @@ struct golos_vesting_api: base_contract_api {
     action_result open(name owner) {
         return open(owner, _symbol, owner);
     }
-    action_result open(name owner, symbol sym, name ram_payer) {
+    action_result open(name owner, symbol sym, name ram_payer = {}) {
         return push(N(open), ram_payer, args()
             ("owner", owner)
             ("symbol", sym)
-            ("ram_payer", ram_payer)
+            ("ram_payer", ram_payer == name{} ? owner : ram_payer)
         );
     }
 


### PR DESCRIPTION
+ forbid withdraw object creation if withdraw_rate = 0; + test
+ erase withdraw object if token account no more exists; + test
+ use `payment` action to send withdrawn tokens; + update tests
+ update boot-sequence/genesis-info to allow `payment` action