### PR TITLE
Dont retry to update gls ctrl authority on each payment.

### DIFF
--- a/genesis/genesis.json.tmpl
+++ b/genesis/genesis.json.tmpl
@@ -15,7 +15,7 @@
 # such a number of posts and this value should be revised.
     "deferred_trx_expiration_window": 10800,
     "max_transaction_delay": 3888000,
-    "max_inline_action_size": 4096,
+    "max_inline_action_size": 32768,
     "max_inline_action_depth": 4,
     "max_authority_depth": 6,
     "ram_size": "8589934592",

--- a/golos.publication/config.hpp
+++ b/golos.publication/config.hpp
@@ -8,8 +8,8 @@ constexpr size_t check_monotonic_steps = 10;
 constexpr unsigned paymssgrwrd_expiration_sec = 3*60*60;
 constexpr unsigned deletevotes_expiration_sec = 3*60*60;
 
-constexpr size_t target_payments_per_trx = 40;
-constexpr size_t max_payments_per_trx    = 50;
+constexpr size_t target_payments_per_trx = 20;
+constexpr size_t max_payments_per_trx    = 20;
 constexpr size_t max_deletions_per_trx   = 100;
 
 static_assert(max_payments_per_trx >= target_payments_per_trx, "max_payments_per_trx < target_payments_per_trx");

--- a/tests/golos.ctrl_tests.cpp
+++ b/tests/golos.ctrl_tests.cpp
@@ -263,8 +263,8 @@ BOOST_FIXTURE_TEST_CASE(register_update_witness, golos_ctrl_tester) try {
 
     prepare_balances();
     vector<std::tuple<name,name,bool>> votes = {
-        {_alice, _w[1], true}, {_alice, _w[2], true}, {_alice, _w[3], false},
-        {_alice, _w[0], true}, {_bob, _w[0], false}, {_w[0], _w[0], false}
+        {_alice, _w[1], true}, {_alice, _w[2], true}, {_alice, _w[3], true},
+        {_alice, _w[0], true}, {_bob,   _w[0], true}, {_w[0],  _w[0], true}
     };
 
     for (const auto& v : votes) {
@@ -443,19 +443,19 @@ BOOST_FIXTURE_TEST_CASE(update_auths, golos_ctrl_tester) try {
     BOOST_TEST_MESSAGE("--- checking that update auths possible only once");
     BOOST_CHECK_EQUAL(success(), ctrl.reg_witness(_w[0], "localhost"));
     BOOST_CHECK_EQUAL(success(), ctrl.vote_witness(_bob, _w[0]));
-    produce_blocks(golos::seconds_to_blocks(_update_auth_period)-1);
+    produce_blocks(golos::seconds_to_blocks(_update_auth_period));
     BOOST_CHECK_EQUAL(success(), ctrl.reg_witness(_w[1], "localhost"));
     BOOST_CHECK_EQUAL(success(), ctrl.vote_witness(_bob, _w[1]));
     auto top_witnesses = ctrl.get_msig_auths();
     std::vector<name> wtns = {_w[0]};
-    BOOST_CHECK(top_witnesses["witnesses"].as<std::vector<name>>().size() ==  wtns.size());
+    BOOST_CHECK_EQUAL(top_witnesses["witnesses"].as<std::vector<name>>().size(),  wtns.size());
 
     BOOST_TEST_MESSAGE("--- checking that update auths possible again");
     produce_blocks(2);
     BOOST_CHECK_EQUAL(success(), ctrl.vote_witness(_alice, _w[1]));
     wtns.push_back(_w[1]);
     top_witnesses = ctrl.get_msig_auths();
-    BOOST_CHECK(top_witnesses["witnesses"].as<std::vector<name>>().size() == wtns.size());
+    BOOST_CHECK_EQUAL(top_witnesses["witnesses"].as<std::vector<name>>().size(), wtns.size());
 } FC_LOG_AND_RETHROW()
 
 


### PR DESCRIPTION
Resolve #765:
- Update last time on each trying to select top leaders.

Resolve #766:
- Increase maximum inline action size to 32 kb

Additional changes:
- update cyberway.contracts to last version.