### PR TITLE
Refactor closing of messages #773

### DIFF
--- a/docs/en-US/golos.publication_contract.md
+++ b/docs/en-US/golos.publication_contract.md
@@ -11,7 +11,7 @@ In addition, this contract contains logic for determining the [payments to autho
 
 ## The list of actions implemented in the golos.publication smart contract
  
-The `golos.publication` smart contract supports the following user actions: [setlimit](#setlimit), [setrules](#setrules), [createmssg](#createmssg), [updatemssg](#updatemssg), [deletemssg](#deletemssg), [upvote](#upvote), [downvote](#downvote), [unvote](#unvote), [closemssg](#closemssg), [reblog](#reblog), [setcurprcnt](#setcurprcnt), [setmaxpayout](#setmaxpayout), [calcrwrdwt](#calcrwrdwt), [paymssgrwrd](#paymssgrwrd) and [setparams](#setparams).
+The `golos.publication` smart contract supports the following user actions: [setlimit](#setlimit), [setrules](#setrules), [createmssg](#createmssg), [updatemssg](#updatemssg), [deletemssg](#deletemssg), [upvote](#upvote), [downvote](#downvote), [unvote](#unvote), [closemssgs](#closemssgs), [reblog](#reblog), [setcurprcnt](#setcurprcnt), [setmaxpayout](#setmaxpayout), [calcrwrdwt](#calcrwrdwt), [paymssgrwrd](#paymssgrwrd) and [setparams](#setparams).
 
 ## setlimit
 
@@ -188,20 +188,17 @@ void unvote(
 To perform the `unvote` action it is required that the transaction should be signed by the account name `voter`.
 
 
-## closemssg
+## closemssgs
 
-The `closemssg` action is internal and unavailable to a user. Used to close a post.  
-The `closemssg` action has the following form:
+The `closemssgs` action is used to close next amount of posts manually by user.  
+The `closemssgs` action has the following form:
 ```
-void close_message(mssgid message_id)
+void close_messages()
 ```
-**Parameter:**  
-  * `message_id` — identifier of the post that is closing. The parameter contains the fields: `author` — author name of the post, `permlink` — unique name of the post within publications of this author.  
+**Parameters:**  
+  * none.  
 
-The `closemssg` action requires fulfillment of conditions:
-  * closing the post should occur after the time `cashout_window:window`;  
-  * transaction should be signed by the account of `golos.publication` smart contract.  
-
+The `closemssgs` action requires no sign.
 
 ## reblog
 The `reblog` action is used to place a post adopted from another author under this smart contract, as well as to add rebloger's own text to the post in the form of note or comment.  

--- a/docs/ru-RU/golos.publication_contract.md
+++ b/docs/ru-RU/golos.publication_contract.md
@@ -5,7 +5,7 @@
 Смарт-контракт `golos.publication` обеспечивает работу с постами, в том числе предоставляет возможность пользователям выполнять следующие действия: публиковать посты, оставлять комментарии, голосовать за посты и закрывать посты, а также обеспечивает выплату вознаграждения авторам постов.  
 
 ## Операции-действия смарт-контракта golos.publication 
-Cмарт-контракт `golos.publication` поддерживает следующие операции-действия: [setlimit](#operaciya-deistvie-setlimit), [setrules](#operaciya-deistvie-setrules), [createmssg](#operaciya-deistvie-createmssg), [updatemssg](#operaciya-deistvie-updatemssg), [deletemssg](#operaciya-deistvie-deletemssg), [downvote](#operaciya-deistvie-downvote), [upvote](#operaciya-deistvie-upvote), [closemssg](#operaciya-deistvie-closemssg), [reblog](#operaciya-deistvie-reblog), [setcurprcnt](#operaciya-deistvie-setcurprcnt), [setmaxpayout](#operaciya-deistvie-setmaxpayout), [calcrwrdwt](#operaciya-deistvie-calcrwrdwt), [paymssgrwrd](#operaciya-deistvie-paymssgrwrd), [setparams](#operaciya-deistvie-setparams).
+Cмарт-контракт `golos.publication` поддерживает следующие операции-действия: [setlimit](#operaciya-deistvie-setlimit), [setrules](#operaciya-deistvie-setrules), [createmssg](#operaciya-deistvie-createmssg), [updatemssg](#operaciya-deistvie-updatemssg), [deletemssg](#operaciya-deistvie-deletemssg), [downvote](#operaciya-deistvie-downvote), [upvote](#operaciya-deistvie-upvote), [closemssgs](#operaciya-deistvie-closemssgs), [reblog](#operaciya-deistvie-reblog), [setcurprcnt](#operaciya-deistvie-setcurprcnt), [setmaxpayout](#operaciya-deistvie-setmaxpayout), [calcrwrdwt](#operaciya-deistvie-calcrwrdwt), [paymssgrwrd](#operaciya-deistvie-paymssgrwrd), [setparams](#operaciya-deistvie-setparams).
 
 ## Операция-действие setlimit
 
@@ -197,19 +197,17 @@ void unvote(
  
 Операция-действие `unvote` требует наличия подписи в транзакции аккаунта `voter`.
 
-## Операция-действие closemssg
+## Операция-действие closemssgs
 
-Операция-действие `closemssg` является внутренней и пользователю недоступна. Используется для закрытия поста.  
-Операция -действие `closemssg` имеет следующий вид:
+Операция-действие `closemssgs` используется для закрытия очередной порции постов, готовых к выплате, вручную пользователем.  
+Операция -действие `closemssgs` имеет следующий вид:
 ```
-void close_message(mssgid message_id)
+void close_messages()
 ```
-Параметр:  
-`message_id` — идентификатор закрывающегося поста. Параметр содержит поля: `author` — автор поста, `permlink` — уникальное имя поста в рамках публикаций данного автора.  
+Параметры:  
+нет.
 
-Операция-действие `closemssg` требует выполнения условий:
-  * закрытие поста должно происходить по истечении времени `cashout_window:window`;  
-  * транзакция должна быть подписана аккаунтом смарт-контракта Golos.publication.  
+Операция-действие `closemssgs` не требует каких-либо подписей.
 
 ## Операция-действие reblog
 

--- a/genesis/genesis-info.json.tmpl
+++ b/genesis/genesis-info.json.tmpl
@@ -281,7 +281,7 @@
             "links": ["cyber.token:transfer", "cyber.token:payment", "gls.vesting:timeout", "gls.vesting:timeoutconv", "gls.vesting:timeoutrdel"]
         },{
             "permission": "gls.publish@code",
-            "links": ["cyber.token:payment", "cyber.token:transfer", "gls.publish:paymssgrwrd", "gls.publish:deletevotes", "cyber.token:bulkpayment", "cyber.token:bulktransfer"]
+            "links": ["cyber.token:payment", "cyber.token:transfer", "gls.publish:closemssgs", "gls.publish:paymssgrwrd", "gls.publish:deletevotes", "cyber.token:bulkpayment", "cyber.token:bulktransfer"]
         },{
             "permission": "gls.publish@calcrwrdwt",
             "links": ["gls.publish:calcrwrdwt"]

--- a/genesis/genesis-info.json.tmpl
+++ b/genesis/genesis-info.json.tmpl
@@ -281,7 +281,7 @@
             "links": ["cyber.token:transfer", "cyber.token:payment", "gls.vesting:timeout", "gls.vesting:timeoutconv", "gls.vesting:timeoutrdel"]
         },{
             "permission": "gls.publish@code",
-            "links": ["cyber.token:payment", "cyber.token:transfer", "gls.publish:closemssg", "gls.publish:paymssgrwrd", "gls.publish:deletevotes", "cyber.token:bulkpayment", "cyber.token:bulktransfer"]
+            "links": ["cyber.token:payment", "cyber.token:transfer", "gls.publish:paymssgrwrd", "gls.publish:deletevotes", "cyber.token:bulkpayment", "cyber.token:bulktransfer"]
         },{
             "permission": "gls.publish@calcrwrdwt",
             "links": ["gls.publish:calcrwrdwt"]

--- a/golos.publication/config.hpp
+++ b/golos.publication/config.hpp
@@ -7,6 +7,7 @@ constexpr int64_t max_cashout_time = 60 * 60 * 24 * 40; //40 days
 constexpr size_t check_monotonic_steps = 10;
 constexpr unsigned paymssgrwrd_expiration_sec = 3*60*60;
 constexpr unsigned deletevotes_expiration_sec = 3*60*60;
+constexpr unsigned closemssgs_expiration_sec  = 3*60*60;
 
 constexpr size_t target_payments_per_trx = 20;
 constexpr size_t max_payments_per_trx    = 20;

--- a/golos.publication/config.hpp
+++ b/golos.publication/config.hpp
@@ -12,6 +12,8 @@ constexpr size_t target_payments_per_trx = 20;
 constexpr size_t max_payments_per_trx    = 20;
 constexpr size_t max_deletions_per_trx   = 100;
 
+constexpr size_t max_closed_posts_per_action = 20;
+
 static_assert(max_payments_per_trx >= target_payments_per_trx, "max_payments_per_trx < target_payments_per_trx");
 
 namespace limit_restorer_domain {//TODO: it will look better in a rule settings

--- a/golos.publication/golos.publication.abi
+++ b/golos.publication/golos.publication.abi
@@ -108,12 +108,7 @@
   {
     "name": "closemssg",
     "base": "",
-    "fields": [
-      {
-        "name": "message_id",
-        "type": "mssgid"
-      }
-    ]
+    "fields": []
   },
   {
     "name": "beneficiary",
@@ -166,6 +161,10 @@
     "base": "",
     "fields": [
       {
+        "name": "author",
+        "type": "name"
+      },
+      {
         "name": "id",
         "type": "uint64"
       },
@@ -200,6 +199,10 @@
       {
         "name": "closed",
         "type": "bool"
+      },
+      {
+        "name": "cashout_time",
+        "type": "uint64"
       },
       {
         "name": "mssg_reward",
@@ -990,6 +993,13 @@
           "unique": "true",
           "orders": [
               {"field": "id", "order": "asc"}
+          ]
+       },
+       {
+          "name": "bycashout",
+          "unique": "false",
+          "orders": [
+              {"field": "cashout_time", "order": "asc"}
           ]
        }
     ]

--- a/golos.publication/golos.publication.abi
+++ b/golos.publication/golos.publication.abi
@@ -106,7 +106,7 @@
     ]
   },
   {
-    "name": "closemssg",
+    "name": "closemssgs",
     "base": "",
     "fields": []
   },
@@ -195,10 +195,6 @@
       {
         "name": "curators_prcnt",
         "type": "percent_t"
-      },
-      {
-        "name": "closed",
-        "type": "bool"
       },
       {
         "name": "cashout_time",
@@ -935,8 +931,8 @@
     "type": "unvote"
   },
   {
-    "name": "closemssg",
-    "type": "closemssg"
+    "name": "closemssgs",
+    "type": "closemssgs"
   },
   {
     "name": "createacc",

--- a/golos.publication/golos.publication.cpp
+++ b/golos.publication/golos.publication.cpp
@@ -532,9 +532,9 @@ void publication::close_messages() {
 
         auto pool_kv = pools.find(mssg_itr->pool_date);
         if (pool_kv == pools.end()) {
-            pools[mssg_itr->pool_date] = *get_pool(pools_table, mssg_itr->pool_date);
+            pool_kv = pools.emplace(mssg_itr->pool_date, *get_pool(pools_table, mssg_itr->pool_date)).first;
         }
-        structures::rewardpool& pool = pools[mssg_itr->pool_date];
+        auto& pool = pool_kv->second;
 
         eosio::check(pool.state.msgs != 0, "LOGIC ERROR! publication::payrewards: pool.msgs is equal to zero");
         atmsp::machine<fixp_t> machine;

--- a/golos.publication/golos.publication.cpp
+++ b/golos.publication/golos.publication.cpp
@@ -38,7 +38,7 @@ extern "C" {
             execute_action(&publication::downvote);
         if (NN(unvote) == action)
             execute_action(&publication::unvote);
-        if (NN(closemssg) == action)
+        if (NN(closemssgs) == action)
             execute_action(&publication::close_messages);
         if (NN(setrules) == action)
             execute_action(&publication::set_rules);
@@ -116,7 +116,7 @@ void publication::create_message(
     std::optional<asset> max_payout = std::nullopt
 ) {
     require_auth(message_id.author);
-    close_messages();
+    send_closemssgs_trx();
 
     eosio::check(message_id.permlink.length() && message_id.permlink.length() < config::max_length,
             "Permlink length is empty or more than 256.");
@@ -295,7 +295,7 @@ void publication::delete_message(structures::mssgid message_id) {
     auto mssg_itr = message_table.find(permlink_itr->id);
     if (mssg_itr != message_table.end()) {
         eosio::check(FP(mssg_itr->state.netshares) <= 0, "Cannot delete a comment with net positive votes.");
-        eosio::check((!mssg_itr->closed || (mssg_itr->mssg_reward.amount == 0)), "Cannot delete comment with unpaid payout");
+        eosio::check((!mssg_itr->closed() || (mssg_itr->mssg_reward.amount == 0)), "Cannot delete comment with unpaid payout");
     }
 
     if (permlink_itr->parentacc) {
@@ -512,45 +512,55 @@ void publication::send_deletevotes_trx(int64_t message_id, name author) {
     trx.send((static_cast<uint128_t>(message_id) << 64) | author.value, _self);
 }
 
-void publication::close_message(structures::mssgid message_id) {
-    require_auth(_self);
-    close_messages();
+void publication::send_closemssgs_trx() {
+    auto cur_time = static_cast<uint64_t>(eosio::current_time_point().time_since_epoch().count());
+    transaction trx(eosio::current_time_point() + eosio::seconds(config::closemssgs_expiration_sec));
+    trx.actions.emplace_back(action{permission_level(_self, config::code_name), _self, "closemssgs"_n, ""});
+    trx.delay_sec = 0;
+    trx.send(static_cast<uint128_t>(cur_time) << 64, _self, true);
 }
 
 void publication::close_messages() {
     auto cur_time = static_cast<uint64_t>(eosio::current_time_point().time_since_epoch().count());
 
+    tables::reward_pools pools_table(_self, _self.value);
+    std::map<uint64_t, structures::rewardpool> pools;
+
+    size_t i = 0;
     tables::message_table message_table(_self, _self.value);
     auto message_index = message_table.get_index<"bycashout"_n>();
-    size_t i = 0;
     for (auto mssg_itr = message_index.begin(); mssg_itr != message_index.end(); ++mssg_itr) {
         if (config::max_closed_posts_per_action <= i++) {
-            break;
+            send_closemssgs_trx();
+            return;
         }
         if (mssg_itr->cashout_time > cur_time) {
             break;
         }
 
-        tables::reward_pools pools(_self, _self.value);
-        auto pool = get_pool(pools, mssg_itr->pool_date);
+        auto pool_kv = pools.find(mssg_itr->pool_date);
+        if (pool_kv == pools.end()) {
+            pools[mssg_itr->pool_date] = *get_pool(pools_table, mssg_itr->pool_date);
+        }
+        structures::rewardpool& pool = pools[mssg_itr->pool_date];
 
-        eosio::check(pool->state.msgs != 0, "LOGIC ERROR! publication::payrewards: pool.msgs is equal to zero");
+        eosio::check(pool.state.msgs != 0, "LOGIC ERROR! publication::payrewards: pool.msgs is equal to zero");
         atmsp::machine<fixp_t> machine;
         fixp_t sharesfn = set_and_run(
                 machine, 
-                pool->rules.mainfunc.code, 
+                pool.rules.mainfunc.code, 
                 {FP(mssg_itr->state.netshares)}, 
-                {{fixp_t(0), FP(pool->rules.mainfunc.maxarg)}});
+                {{fixp_t(0), FP(pool.rules.mainfunc.maxarg)}});
 
         asset mssg_reward;
-        auto state = pool->state;
+        auto& state = pool.state;
         int64_t payout = 0;
         if(state.msgs == 1) {
             payout = state.funds.amount; //if we have the only message in the pool, the author receives a reward anyway
             eosio::check(state.rshares == mssg_itr->state.netshares,
-                    "LOGIC ERROR! publication::payrewards: pool->rshares != mssg_itr->netshares for last message");
+                    "LOGIC ERROR! publication::payrewards: pool.rshares != mssg_itr->netshares for last message");
             eosio::check(state.rsharesfn == sharesfn.data(),
-                    "LOGIC ERROR! publication::payrewards: pool->rsharesfn != sharesfn.data() for last message");
+                    "LOGIC ERROR! publication::payrewards: pool.rsharesfn != sharesfn.data() for last message");
             state.funds.amount = 0;
             state.rshares = 0;
             state.rsharesfn = 0;
@@ -592,30 +602,33 @@ void publication::close_messages() {
         mssg_reward = asset(payout, state.funds.symbol); 
 
         message_index.modify(mssg_itr, name(), [&]( auto &item ) {
-                item.closed = true;
                 item.cashout_time = microseconds::maximum().count();
                 item.mssg_reward = mssg_reward;
             });
 
-        bool pool_erased = false;
         state.msgs--;
-        if(state.msgs == 0) {
-            if(pool != --pools.end()) {
-                send_poolerase_event(*pool);
-
-                pools.erase(pool);
-                pool_erased = true;
-            }
-        }
-        if(!pool_erased)
-            pools.modify(pool, _self, [&](auto &item) {
-                item.state = state;
-                send_poolstate_event(item);
-            });
 
         tables::permlink_table permlink_table(_self, mssg_itr->author.value);
         auto permlink_itr = permlink_table.find(mssg_itr->id);
         send_postreward_trx(mssg_itr->id, structures::mssgid{mssg_itr->author, permlink_itr->value});
+    }
+
+    for (auto& pool_kv : pools) {
+        auto pool = pools_table.find(pool_kv.first);
+        bool pool_erased = false;
+        if(pool_kv.second.state.msgs == 0) {
+            if(pool != --pools_table.end()) {
+                send_poolerase_event(*pool);
+
+                pools_table.erase(pool);
+                pool_erased = true;
+            }
+        }
+        if(!pool_erased)
+            pools_table.modify(pool, _self, [&](auto &item) {
+                item.state = pool_kv.second.state;
+                send_poolstate_event(item);
+            });
     }
 }
 
@@ -657,7 +670,7 @@ void publication::paymssgrwrd(structures::mssgid message_id) {
     tables::message_table message_table(_self, _self.value);
     auto mssg_itr = message_table.find(permlink_itr->id);
     eosio::check(mssg_itr != message_table.end(), "Message doesn't exist in cashout window.");
-    eosio::check(mssg_itr->closed, "Message doesn't closed.");
+    eosio::check(mssg_itr->closed(), "Message doesn't closed.");
 
     auto payout = mssg_itr->mssg_reward;
     tables::reward_pools pools(_self, _self.value);
@@ -729,13 +742,6 @@ void publication::paymssgrwrd(structures::mssgid message_id) {
     }
 }
 
-void publication::close_message_timer(structures::mssgid message_id, uint64_t id, uint64_t delay_sec) {
-    transaction trx;
-    trx.actions.emplace_back(action{permission_level(_self, config::code_name), _self, "closemssg"_n, message_id});
-    trx.delay_sec = delay_sec;
-    trx.send((static_cast<uint128_t>(id) << 64) | message_id.author.value, _self);
-}
-
 void publication::check_upvote_time(uint64_t cur_time, uint64_t mssg_date) {
     const auto& cashout_window_param = params().cashout_window_param;
     eosio::check(
@@ -756,7 +762,7 @@ fixp_t publication::calc_available_rshares(name voter, int16_t weight, uint64_t 
 
 void publication::set_vote(name voter, const structures::mssgid& message_id, int16_t weight) {
     require_auth(voter);
-    close_messages();
+    send_closemssgs_trx();
 
     auto get_calc_sharesfn = [&](auto mainfunc_code, auto netshares, auto mainfunc_maxarg) {
         atmsp::machine<fixp_t> machine;
@@ -774,7 +780,7 @@ void publication::set_vote(name voter, const structures::mssgid& message_id, int
     tables::message_table message_table(_self, _self.value);
     auto mssg_itr = message_table.find(permlink_itr->id);
     eosio::check(mssg_itr != message_table.end(), "Message doesn't exist in cashout window.");
-    eosio::check(!mssg_itr->closed, "Message is closed.");
+    eosio::check(!mssg_itr->closed(), "Message is closed.");
 
     tables::reward_pools pools(_self, _self.value);
     auto pool = get_pool(pools, mssg_itr->pool_date);
@@ -947,7 +953,7 @@ void publication::on_transfer(name from, name to, eosio::asset quantity, std::st
     tables::reward_pools pools(_self, _self.value);
     fill_depleted_pool(pools, quantity, pools.end());
 
-    close_messages();
+    send_closemssgs_trx();
 }
 
 void publication::set_limit(

--- a/golos.publication/golos.publication.hpp
+++ b/golos.publication/golos.publication.hpp
@@ -25,6 +25,7 @@ public:
     void downvote(name voter, structures::mssgid message_id, uint16_t weight);
     void unvote(name voter, structures::mssgid message_id);
     void close_message(structures::mssgid message_id);
+    void close_messages();
     void set_params(std::vector<posting_params> params);
     void reblog(name rebloger, structures::mssgid message_id, std::string headermssg, std::string bodymssg);
     void erase_reblog(name rebloger, structures::mssgid message_id);

--- a/golos.publication/golos.publication.hpp
+++ b/golos.publication/golos.publication.hpp
@@ -70,7 +70,6 @@ private:
     const auto& get_message(const tables::message_table& messages, const structures::mssgid& message_id);
     void send_postreward_trx(uint64_t id, const structures::mssgid& message_id);
     void send_deletevotes_trx(int64_t message_id, name author);
-    void send_closemssgs_trx();
 };
 
 } // golos

--- a/golos.publication/golos.publication.hpp
+++ b/golos.publication/golos.publication.hpp
@@ -24,7 +24,6 @@ public:
     void upvote(name voter, structures::mssgid message_id, uint16_t weight);
     void downvote(name voter, structures::mssgid message_id, uint16_t weight);
     void unvote(name voter, structures::mssgid message_id);
-    void close_message(structures::mssgid message_id);
     void close_messages();
     void set_params(std::vector<posting_params> params);
     void reblog(name rebloger, structures::mssgid message_id, std::string headermssg, std::string bodymssg);
@@ -36,7 +35,6 @@ public:
     void deletevotes(int64_t message_id, name author);
 private:
     const posting_state& params();
-    void close_message_timer(structures::mssgid message_id, uint64_t id, uint64_t delay_sec);
     void set_vote(name voter, const structures::mssgid &message_id, int16_t weight);
     void fill_depleted_pool(tables::reward_pools& pools, asset quantity,
         tables::reward_pools::const_iterator excluded);
@@ -72,6 +70,7 @@ private:
     const auto& get_message(const tables::message_table& messages, const structures::mssgid& message_id);
     void send_postreward_trx(uint64_t id, const structures::mssgid& message_id);
     void send_deletevotes_trx(int64_t message_id, name author);
+    void send_closemssgs_trx();
 };
 
 } // golos

--- a/golos.publication/objects.hpp
+++ b/golos.publication/objects.hpp
@@ -50,7 +50,6 @@ struct message {
     uint16_t rewardweight;  // percent
     messagestate state;
     uint16_t curators_prcnt;
-    bool closed = false;
     uint64_t cashout_time;
     eosio::asset mssg_reward;
     eosio::asset max_payout;
@@ -62,6 +61,10 @@ struct message {
 
     uint64_t by_cashout() const {
         return cashout_time;
+    }
+
+    bool closed() const {
+        return cashout_time == microseconds::maximum().count();
     }
 };
 

--- a/golos.publication/objects.hpp
+++ b/golos.publication/objects.hpp
@@ -41,6 +41,7 @@ struct messagestate {
 struct message {
     message() = default;
 
+    name author;
     uint64_t id;
     uint64_t date;
     uint64_t pool_date;
@@ -50,12 +51,17 @@ struct message {
     messagestate state;
     uint16_t curators_prcnt;
     bool closed = false;
+    uint64_t cashout_time;
     eosio::asset mssg_reward;
     eosio::asset max_payout;
     int64_t paid_amount = 0;
 
     uint64_t primary_key() const {
         return id;
+    }
+
+    uint64_t by_cashout() const {
+        return cashout_time;
     }
 };
 
@@ -215,7 +221,8 @@ namespace tables {
 using namespace eosio;
 
 using id_index = indexed_by<N(primary), const_mem_fun<structures::message, uint64_t, &structures::message::primary_key>>;
-using message_table = multi_index<N(message), structures::message, id_index>;
+using cashout_index = indexed_by<N(bycashout), const_mem_fun<structures::message, uint64_t, &structures::message::by_cashout>>;
+using message_table = multi_index<N(message), structures::message, id_index, cashout_index>;
 
 using permlink_id_index = indexed_by<N(primary), const_mem_fun<structures::permlink, uint64_t, &structures::permlink::primary_key>>;
 using permlink_value_index = indexed_by<N(byvalue), const_mem_fun<structures::permlink, std::string, &structures::permlink::secondary_key>>;

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -32,10 +32,8 @@ def glsPublish_createmssg(action):
     parent = "%s/%s" % (args['parent_id']['author'], args['parent_id']['permlink']) if args['parent_id']['author'] else args['parent_id']['permlink']
     return "%s/%s (%s)    '%s'" % (args['message_id']['author'], args['message_id']['permlink'], parent, args['headermssg'])
 
-def glsPublish_closemssg(action):
-    args = action['args']
-    print(">>> ", args)
-    return "%s/%s" % (args['message_id']['author'], args['message_id']['permlink'])
+def glsPublish_closemssgs(action):
+    return ""
 
 def glsPublish_upvote(action):
     args = action['args']
@@ -85,7 +83,7 @@ _actions = (
     ('cyber.token',   None,    'issue',    cyberToken_issue),
     ('cyber.token',   None,    'transfer', cyberToken_transfer),
     ('gls.publish',   None,    'createmssg', glsPublish_createmssg),
-    ('gls.publish',   None,    'closemssg',  glsPublish_closemssg),
+    ('gls.publish',   None,    'closemssgs',  glsPublish_closemssgs),
     ('gls.publish',   None,    'upvote',     glsPublish_upvote),
     ('gls.publish',   None,    'downvote',   glsPublish_downvote),
     ('gls.publish',   None,    'unvote',     glsPublish_unvote),

--- a/scripts/golos-boot-sequence/golos-boot-sequence.py
+++ b/scripts/golos-boot-sequence/golos-boot-sequence.py
@@ -56,7 +56,7 @@ def fillGolosAccounts(golosAccounts):
         ('gls.publish',  True,       'golos.publication',
             [("owner",       [], ["gls@owner"], []),
              ("active",      [], ["gls@active"], []),
-             ("code",        [], ["gls.publish@cyber.code"], ["cyber.token:transfer", "cyber.token:payment", "cyber.token:bulktransfer", "cyber.token:bulkpayment", "gls.publish:closemssg", "gls.publish:paymssgrwrd", "gls.publish:deletevotes"]),
+             ("code",        [], ["gls.publish@cyber.code"], ["cyber.token:transfer", "cyber.token:payment", "cyber.token:bulktransfer", "cyber.token:bulkpayment", "gls.publish:paymssgrwrd", "gls.publish:deletevotes"]),
              ("calcrwrdwt",  [], ["gls.charge@cyber.code"], ["gls.publish:calcrwrdwt"]),
             ]),
         ('gls.social',   True,       'golos.social',

--- a/scripts/golos-boot-sequence/golos-boot-sequence.py
+++ b/scripts/golos-boot-sequence/golos-boot-sequence.py
@@ -56,7 +56,7 @@ def fillGolosAccounts(golosAccounts):
         ('gls.publish',  True,       'golos.publication',
             [("owner",       [], ["gls@owner"], []),
              ("active",      [], ["gls@active"], []),
-             ("code",        [], ["gls.publish@cyber.code"], ["cyber.token:transfer", "cyber.token:payment", "cyber.token:bulktransfer", "cyber.token:bulkpayment", "gls.publish:paymssgrwrd", "gls.publish:deletevotes"]),
+             ("code",        [], ["gls.publish@cyber.code"], ["cyber.token:transfer", "cyber.token:payment", "cyber.token:bulktransfer", "cyber.token:bulkpayment", "gls.publish:closemssgs", "gls.publish:paymssgrwrd", "gls.publish:deletevotes"]),
              ("calcrwrdwt",  [], ["gls.charge@cyber.code"], ["gls.publish:calcrwrdwt"]),
             ]),
         ('gls.social',   True,       'golos.social',

--- a/scripts/posting_script/posts.py
+++ b/scripts/posting_script/posts.py
@@ -13,19 +13,6 @@ def create_tags(metadata_tags):
 
     return tags
 
-def create_trx(author, id_message):
-    trx = ""
-    command = "/home/deploy/cyberway/build/programs/cleos/cleos push action gls.publish closemssg '{\"account\":\""+author+"\", \"permlink\":\""+str(id_message)+"\"}' -p gls.publish -d --return-packed"
-    result = os.popen(command)
-
-    try:
-        json_trx = json.loads(result.read())
-        trx = json["packed_trx"]
-    except Exception: 
-        trx = ""
-
-    return trx;
-
 
 def convert_posts():
     golos_posts = dbs.golos_db['comment_object']
@@ -52,25 +39,6 @@ def convert_posts():
                 "sumcuratorsw": 0
             }
         
-            isClosedMessage = True
-            expiretion = timedelta(minutes = 30)
-            date_close = datetime.strptime("2106-02-07T06:28:15", '%Y-%m-%dT%H:%M:%S').isoformat()
-            if (doc["cashout_time"].isoformat() != date_close and doc["cashout_time"].isoformat() > datetime.datetime.now().isoformat()):
-                delay_trx = {
-                    "trx_id": "",
-                    "sender": doc["author"],
-                    "sender_id": dbs.convert_hash(doc["permlink"]) << 64 | doc["author"],
-                    "delay_until" : doc["cashout_time"].isoformat(), 
-                    "expiration" : doc["cashout_time"].isoformat() + expiretion, 
-                    "published" : doc["created"], 
-                    "packed_trx" : create_trx(doc["author"], dbs.convert_hash(doc["permlink"])), 
-                    "_SCOPE_" : "",
-                    "_PAYER_" : "",
-                    "_SIZE_" : NumberLong(156) 
-                }
-                dbs.cyberway_db['gtransaction'].save(delay_trx)
-                isClosedMessage = False
-
             message = {
                 "id": dbs.convert_hash(doc["permlink"]),
                 "date": doc["last_update"],
@@ -80,8 +48,8 @@ def convert_posts():
                 "beneficiaries": "",
                 "rewardweight": doc["reward_weight"],
                 "state": messagestate,
+                "cashout_time": doc["cashout_time"],
                 "childcount": doc["children"],
-                "closed": isClosedMessage,
                 "level": doc["depth"],
                 "_SCOPE_": doc["author"],
                 "_PAYER_": "gls.publish",

--- a/tests/golos.posting_test_api.hpp
+++ b/tests/golos.posting_test_api.hpp
@@ -17,7 +17,6 @@ struct golos_posting_api: base_contract_api {
         _tester->install_contract(_code, contracts::posting_wasm(), contracts::posting_abi());
 
         _tester->set_authority(_code, cfg::code_name, create_code_authority({_code}), "active");
-        _tester->link_authority(_code, _code, cfg::code_name, N(closemssg));
         _tester->link_authority(_code, _code, cfg::code_name, N(paymssgrwrd));
         _tester->link_authority(_code, _code, cfg::code_name, N(deletevotes));
         _tester->link_authority(_code, token_name, cfg::code_name, N(transfer));
@@ -174,6 +173,12 @@ struct golos_posting_api: base_contract_api {
         return push(N(setparams), _code, args()
             ("params", json_str_to_obj(json_params)));
     }
+    action_result closemssg(account_name signer) {
+        return push(N(closemssg), signer, args());
+    }
+    action_result closemssg() {
+        return closemssg(_code);
+    }
 
 
     action_result init_default_params() {
@@ -228,7 +233,7 @@ struct golos_posting_api: base_contract_api {
     }
 
     variant get_message(account_name acc, uint64_t id) {
-        return _tester->get_chaindb_struct(_code, acc, N(message), id, "message");
+        return _tester->get_chaindb_struct(_code, _code, N(message), id, "message");
     }
 
     variant get_permlink(mssgid message_id) {
@@ -259,7 +264,7 @@ struct golos_posting_api: base_contract_api {
     }
 
     std::vector<variant> get_messages(account_name user) {
-        auto raw_messages = _tester->get_all_chaindb_rows(_code, user, N(message), false);
+        auto raw_messages = _tester->get_all_chaindb_rows(_code, _code, N(message), false);
         auto raw_permlinks = _tester->get_all_chaindb_rows(_code, user, N(permlink), false);
 
         std::map<uint64_t, variant> src_permlinks_map;
@@ -270,13 +275,16 @@ struct golos_posting_api: base_contract_api {
         std::vector<variant> messages;
         messages.reserve(raw_messages.size());
         for (auto& src_mssg:  raw_messages) {
+            auto src_perm = src_permlinks_map.find(src_mssg["id"].as_uint64());
+            if (src_perm == src_permlinks_map.end()) {
+                continue;
+            }
             mvo dst_mssg(src_mssg.get_object());
-            auto& src_perm = src_permlinks_map[src_mssg["id"].as_uint64()];
 
-            for (auto entry: src_perm.get_object()) {
+            for (auto entry: src_perm->second.get_object()) {
                 dst_mssg(entry.key(), entry.value());
             }
-            dst_mssg("permlink", src_perm["value"]);
+            dst_mssg("permlink", src_perm->second["value"]);
             messages.emplace_back(variant(dst_mssg));
         }
 

--- a/tests/golos.posting_test_api.hpp
+++ b/tests/golos.posting_test_api.hpp
@@ -17,6 +17,7 @@ struct golos_posting_api: base_contract_api {
         _tester->install_contract(_code, contracts::posting_wasm(), contracts::posting_abi());
 
         _tester->set_authority(_code, cfg::code_name, create_code_authority({_code}), "active");
+        _tester->link_authority(_code, _code, cfg::code_name, N(closemssgs));
         _tester->link_authority(_code, _code, cfg::code_name, N(paymssgrwrd));
         _tester->link_authority(_code, _code, cfg::code_name, N(deletevotes));
         _tester->link_authority(_code, token_name, cfg::code_name, N(transfer));
@@ -173,11 +174,11 @@ struct golos_posting_api: base_contract_api {
         return push(N(setparams), _code, args()
             ("params", json_str_to_obj(json_params)));
     }
-    action_result closemssg(account_name signer) {
-        return push(N(closemssg), signer, args());
+    action_result closemssgs(account_name signer) {
+        return push(N(closemssgs), signer, args());
     }
-    action_result closemssg() {
-        return closemssg(_code);
+    action_result closemssgs() {
+        return closemssgs(_code);
     }
 
 
@@ -232,7 +233,7 @@ struct golos_posting_api: base_contract_api {
         return _tester->get_chaindb_struct(_code, acc, N(permlink), id, "permlink");
     }
 
-    variant get_message(account_name acc, uint64_t id) {
+    variant get_message(uint64_t id) {
         return _tester->get_chaindb_struct(_code, _code, N(message), id, "message");
     }
 
@@ -250,7 +251,7 @@ struct golos_posting_api: base_contract_api {
     variant get_message(mssgid message_id) {
         auto permlink = get_permlink(message_id);
         if (!permlink.is_null() && permlink.get_object().size()) {
-            return get_message(message_id.author, permlink["id"].as_uint64());
+            return get_message(permlink["id"].as_uint64());
         }
         return variant();
     }

--- a/tests/golos.publication_rewards_tests.cpp
+++ b/tests/golos.publication_rewards_tests.cpp
@@ -777,7 +777,7 @@ BOOST_FIXTURE_TEST_CASE(timepenalty_test, reward_calcs_tester) try {
     BOOST_TEST_MESSAGE("--- state before post close");
     show();
     BOOST_TEST_MESSAGE("--- close post and check rewards");
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     check();
     show();
 } FC_LOG_AND_RETHROW()
@@ -851,7 +851,7 @@ BOOST_FIXTURE_TEST_CASE(limits_test, reward_calcs_tester) try {
 
     BOOST_TEST_MESSAGE("--- waiting");
     produce_blocks(golos::seconds_to_blocks(150));  // TODO: remove magic number
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     check();
     produce_blocks(golos::seconds_to_blocks(150));  // TODO: remove magic number
     check();
@@ -1005,7 +1005,7 @@ BOOST_FIXTURE_TEST_CASE(golos_curation_test, reward_calcs_tester) try {
     BOOST_TEST_MESSAGE("--- _stranger voted");
     check();
     produce_blocks(golos::seconds_to_blocks(150));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     check();
 } FC_LOG_AND_RETHROW()
 
@@ -1039,7 +1039,7 @@ BOOST_FIXTURE_TEST_CASE(close_token_acc_test, reward_calcs_tester) try {
 
     auto forum_name_balance = token.get_account(_forum_name)["payments"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_GT(token.get_account(_forum_name)["payments"].as<asset>(), forum_name_balance); 
     check();
@@ -1078,7 +1078,7 @@ BOOST_FIXTURE_TEST_CASE(close_vest_acc_test, reward_calcs_tester) try {
 
     auto forum_name_balance = token.get_account(_forum_name)["payments"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_GT(token.get_account(_forum_name)["payments"].as<asset>(), forum_name_balance); 
     check();
@@ -1133,7 +1133,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     auto voter_amount = vest.get_balance_raw(_users[18])["vesting"].as<asset>();
     auto delegator_amount = vest.get_balance_raw(_users[2])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[18])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[2])["vesting"].as<asset>(), delegator_amount);
@@ -1155,7 +1155,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     voter_amount = vest.get_balance_raw(_users[19])["vesting"].as<asset>();
     delegator_amount = vest.get_balance_raw(_users[3])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[19])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[3])["vesting"].as<asset>(), delegator_amount);
@@ -1177,7 +1177,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     voter_amount = vest.get_balance_raw(_users[20])["vesting"].as<asset>();
     delegator_amount = vest.get_balance_raw(_users[4])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[20])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_EQUAL(vest.get_balance_raw(_users[4])["vesting"].as<asset>(), delegator_amount);
@@ -1204,7 +1204,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     auto delegator2_amount = vest.get_balance_raw(_users[6])["vesting"].as<asset>();
     auto delegator3_amount = vest.get_balance_raw(_users[7])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[21])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[5])["vesting"].as<asset>(), delegator1_amount);
@@ -1232,7 +1232,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     delegator2_amount = vest.get_balance_raw(_users[9])["vesting"].as<asset>();
     delegator3_amount = vest.get_balance_raw(_users[10])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[22])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[8])["vesting"].as<asset>(), delegator1_amount);
@@ -1261,7 +1261,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     delegator3_amount = vest.get_balance_raw(_users[13])["vesting"].as<asset>();
     BOOST_CHECK_EQUAL(post.get_vote(_users[0], 0)["delegators"].size(), 1);
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     std::vector<account_name> dlg_vec_db;
     std::vector<account_name> dlg_vec_st{_users[11], _users[12], _users[13]};
@@ -1316,7 +1316,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     BOOST_CHECK_EQUAL(vote_dlg.size(), 1);
     BOOST_CHECK_EQUAL(vote_dlg[(size_t)0]["interest_rate"].as<uint16_t>(), cfg::_100percent);
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     
     BOOST_CHECK_EQUAL(voter_amount.get_amount(), 0);
@@ -1370,7 +1370,7 @@ BOOST_FIXTURE_TEST_CASE(a_lot_of_delegators_test, reward_calcs_tester) try {
     }
     BOOST_TEST_MESSAGE("--- all users have voted");
     produce_blocks(golos::seconds_to_blocks(150));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     check();
 } FC_LOG_AND_RETHROW()
 
@@ -1416,7 +1416,7 @@ BOOST_FIXTURE_TEST_CASE(posting_bw_penalty, reward_calcs_tester) try {
         set_charge();
         BOOST_CHECK_EQUAL(success(), create_message({_users[0], "permlink" + std::to_string(i)}));
         charge += cfg::_100percent;
-        BOOST_TEST_CHECK(post.get_message(_users[0], i+1)["rewardweight"].as<uint16_t>(), cfg::_100percent);
+        BOOST_TEST_CHECK(post.get_message(i+1)["rewardweight"].as<uint16_t>(), cfg::_100percent);
         produce_blocks(golos::seconds_to_blocks(five_min));
     }
 
@@ -1424,7 +1424,7 @@ BOOST_FIXTURE_TEST_CASE(posting_bw_penalty, reward_calcs_tester) try {
     set_charge();
     BOOST_CHECK_EQUAL(success(), create_message({_users[0], "permlink5"}));
     charge += cfg::_100percent;
-    auto reward_weight_db = post.get_message(_users[0], 5)["rewardweight"].as<double>();
+    auto reward_weight_db = post.get_message(5)["rewardweight"].as<double>();
     double reward_weight_st = _state.pools.rbegin()->messages.back().reward_weight;
     BOOST_CHECK(reward_weight_db < cfg::_100percent);
     CHECK_EQUAL_WITH_DELTA(reward_weight_db/cfg::_100percent, reward_weight_st, reward_weight_delta);
@@ -1433,7 +1433,7 @@ BOOST_FIXTURE_TEST_CASE(posting_bw_penalty, reward_calcs_tester) try {
     produce_blocks();
 
     produce_blocks(golos::seconds_to_blocks(window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     check();
 } FC_LOG_AND_RETHROW()
 
@@ -1499,7 +1499,7 @@ BOOST_FIXTURE_TEST_CASE(message_max_payout_test, reward_calcs_tester) try {
     const auto alice3_vest = vest.get_balance_raw(N(alice3))["vesting"].as<asset>();
     const auto alice4_vest = vest.get_balance_raw(N(alice4))["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     BOOST_TEST_MESSAGE("--- rewards");
     check();
     show();

--- a/tests/golos.publication_rewards_tests.cpp
+++ b/tests/golos.publication_rewards_tests.cpp
@@ -734,7 +734,6 @@ BOOST_FIXTURE_TEST_CASE(basic_tests, reward_calcs_tester) try {
 
     BOOST_TEST_MESSAGE("--- waiting");
     produce_blocks(golos::seconds_to_blocks(99));   // TODO: remove magic number
-    check();
     BOOST_TEST_MESSAGE("--- create_message: why");
     BOOST_CHECK_EQUAL(success(), create_message({N(why), "why-not"}, {N(), ""}, {{N(alice5), 5000}, {N(bob5), 2500}}));
     check();
@@ -778,6 +777,7 @@ BOOST_FIXTURE_TEST_CASE(timepenalty_test, reward_calcs_tester) try {
     BOOST_TEST_MESSAGE("--- state before post close");
     show();
     BOOST_TEST_MESSAGE("--- close post and check rewards");
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
     check();
     show();
 } FC_LOG_AND_RETHROW()
@@ -851,6 +851,7 @@ BOOST_FIXTURE_TEST_CASE(limits_test, reward_calcs_tester) try {
 
     BOOST_TEST_MESSAGE("--- waiting");
     produce_blocks(golos::seconds_to_blocks(150));  // TODO: remove magic number
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
     check();
     produce_blocks(golos::seconds_to_blocks(150));  // TODO: remove magic number
     check();
@@ -1003,7 +1004,8 @@ BOOST_FIXTURE_TEST_CASE(golos_curation_test, reward_calcs_tester) try {
     BOOST_CHECK_EQUAL(success(), addvote(_stranger, {_users[0], "permlink"}, 10000));
     BOOST_TEST_MESSAGE("--- _stranger voted");
     check();
-    produce_blocks(golos::seconds_to_blocks(150));    
+    produce_blocks(golos::seconds_to_blocks(150));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
     check();
 } FC_LOG_AND_RETHROW()
 
@@ -1037,6 +1039,8 @@ BOOST_FIXTURE_TEST_CASE(close_token_acc_test, reward_calcs_tester) try {
 
     auto forum_name_balance = token.get_account(_forum_name)["payments"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    produce_block();
     BOOST_CHECK_GT(token.get_account(_forum_name)["payments"].as<asset>(), forum_name_balance); 
     check();
 } FC_LOG_AND_RETHROW()
@@ -1074,6 +1078,8 @@ BOOST_FIXTURE_TEST_CASE(close_vest_acc_test, reward_calcs_tester) try {
 
     auto forum_name_balance = token.get_account(_forum_name)["payments"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    produce_block();
     BOOST_CHECK_GT(token.get_account(_forum_name)["payments"].as<asset>(), forum_name_balance); 
     check();
 } FC_LOG_AND_RETHROW()
@@ -1127,6 +1133,8 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     auto voter_amount = vest.get_balance_raw(_users[18])["vesting"].as<asset>();
     auto delegator_amount = vest.get_balance_raw(_users[2])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[18])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[2])["vesting"].as<asset>(), delegator_amount);
     check();
@@ -1147,6 +1155,8 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     voter_amount = vest.get_balance_raw(_users[19])["vesting"].as<asset>();
     delegator_amount = vest.get_balance_raw(_users[3])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[19])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[3])["vesting"].as<asset>(), delegator_amount);
     check();
@@ -1167,6 +1177,8 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     voter_amount = vest.get_balance_raw(_users[20])["vesting"].as<asset>();
     delegator_amount = vest.get_balance_raw(_users[4])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[20])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_EQUAL(vest.get_balance_raw(_users[4])["vesting"].as<asset>(), delegator_amount);
     check();
@@ -1192,6 +1204,8 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     auto delegator2_amount = vest.get_balance_raw(_users[6])["vesting"].as<asset>();
     auto delegator3_amount = vest.get_balance_raw(_users[7])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[21])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[5])["vesting"].as<asset>(), delegator1_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[6])["vesting"].as<asset>(), delegator2_amount);
@@ -1218,6 +1232,8 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     delegator2_amount = vest.get_balance_raw(_users[9])["vesting"].as<asset>();
     delegator3_amount = vest.get_balance_raw(_users[10])["vesting"].as<asset>();
     produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    produce_block();
     BOOST_CHECK_GT(vest.get_balance_raw(_users[22])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[8])["vesting"].as<asset>(), delegator1_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[9])["vesting"].as<asset>(), delegator2_amount);
@@ -1245,6 +1261,8 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     delegator3_amount = vest.get_balance_raw(_users[13])["vesting"].as<asset>();
     BOOST_CHECK_EQUAL(post.get_vote(_users[0], 0)["delegators"].size(), 1);
     produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    produce_block();
     std::vector<account_name> dlg_vec_db;
     std::vector<account_name> dlg_vec_st{_users[11], _users[12], _users[13]};
     for (auto dlg_obj : vest.get_delegators())
@@ -1298,6 +1316,8 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     BOOST_CHECK_EQUAL(vote_dlg.size(), 1);
     BOOST_CHECK_EQUAL(vote_dlg[(size_t)0]["interest_rate"].as<uint16_t>(), cfg::_100percent);
     produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    produce_block();
     
     BOOST_CHECK_EQUAL(voter_amount.get_amount(), 0);
     BOOST_CHECK_EQUAL(vest.get_balance_raw(_users[24])["vesting"].as<asset>(), voter_amount);
@@ -1349,7 +1369,8 @@ BOOST_FIXTURE_TEST_CASE(a_lot_of_delegators_test, reward_calcs_tester) try {
         BOOST_TEST_MESSAGE("--- " << name{_users[i]}.to_string() << " voted; i = " << i);
     }
     BOOST_TEST_MESSAGE("--- all users have voted");
-    produce_blocks(golos::seconds_to_blocks(150));    
+    produce_blocks(golos::seconds_to_blocks(150));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
     check();
 } FC_LOG_AND_RETHROW()
 
@@ -1412,6 +1433,7 @@ BOOST_FIXTURE_TEST_CASE(posting_bw_penalty, reward_calcs_tester) try {
     produce_blocks();
 
     produce_blocks(golos::seconds_to_blocks(window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
     check();
 } FC_LOG_AND_RETHROW()
 
@@ -1476,7 +1498,8 @@ BOOST_FIXTURE_TEST_CASE(message_max_payout_test, reward_calcs_tester) try {
     const auto alice2_vest = vest.get_balance_raw(N(alice2))["vesting"].as<asset>();
     const auto alice3_vest = vest.get_balance_raw(N(alice3))["vesting"].as<asset>();
     const auto alice4_vest = vest.get_balance_raw(N(alice4))["vesting"].as<asset>();
-    produce_blocks(golos::seconds_to_blocks(post.window));   // TODO: remove magic number
+    produce_blocks(golos::seconds_to_blocks(post.window));
+    BOOST_CHECK_EQUAL(success(), post.closemssg());
     BOOST_TEST_MESSAGE("--- rewards");
     check();
     show();

--- a/tests/golos.publication_tests.cpp
+++ b/tests/golos.publication_tests.cpp
@@ -585,22 +585,6 @@ BOOST_FIXTURE_TEST_CASE(comments_cashout_time_test, golos_publication_tester) tr
 
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(comments_closing, golos_publication_tester) try {
-    BOOST_TEST_MESSAGE("comments_closing");
-    init();
-    auto need_blocks = seconds_to_blocks(post.window);
-
-    BOOST_TEST_MESSAGE("--- checking that creating message triggers closing");
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink"}));
-    produce_blocks(need_blocks);
-    BOOST_CHECK_EQUAL(success(), post.create_msg({N(chucknorris), "permlink"}));
-    produce_block();
-    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"}).is_null(), true);
-
-    BOOST_TEST_MESSAGE("--- checking that creating message triggers closing");
-
-} FC_LOG_AND_RETHROW()
-
 BOOST_FIXTURE_TEST_CASE(data_validation, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("data_validation_test.");
     init();

--- a/tests/golos.publication_tests.cpp
+++ b/tests/golos.publication_tests.cpp
@@ -335,7 +335,7 @@ BOOST_FIXTURE_TEST_CASE(delete_message, golos_publication_tester) try {
     BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "child-done"}).is_null(), false);
 
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink-done"}).is_null(), true);
     BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "child-done"}).is_null(), true);
@@ -391,7 +391,7 @@ BOOST_FIXTURE_TEST_CASE(upvote, golos_publication_tester) try {
     produce_block();
     //BOOST_CHECK_EQUAL(err.upvote_near_close, vote_jackie(cfg::_100percent));          // TODO Fix broken test GolosChain/golos-smart#410
     produce_blocks(seconds_to_blocks(post.upvote_lockout) - 1);
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     //BOOST_CHECK_EQUAL(err.upvote_near_close, vote_jackie(cfg::_100percent));          // TODO Fix broken test GolosChain/golos-smart#410
 
     BOOST_TEST_MESSAGE("--- succeed vote after cashout");
@@ -436,7 +436,7 @@ BOOST_FIXTURE_TEST_CASE(downvote, golos_publication_tester) try {
 
     BOOST_TEST_MESSAGE("--- succeed vote after cashout");
     produce_blocks(seconds_to_blocks(post.window) - post.max_vote_changes - 1);
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_EQUAL(err.no_message, vote_jackie(cfg::_100percent));
 } FC_LOG_AND_RETHROW()
@@ -553,7 +553,7 @@ BOOST_FIXTURE_TEST_CASE(comments_cashout_time_test, golos_publication_tester) tr
     BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"}).is_null(), false);
 
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
 
     BOOST_TEST_MESSAGE("--- checking that messages was closed.");
@@ -564,7 +564,7 @@ BOOST_FIXTURE_TEST_CASE(comments_cashout_time_test, golos_publication_tester) tr
     BOOST_CHECK_EQUAL(post.get_message({N(chucknorris), "comment-permlink"}).is_null(), false);
 
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_TEST_MESSAGE("--- checking that comment was closed.");
     BOOST_CHECK_EQUAL(post.get_message({N(chucknorris), "comment-permlink"}).is_null(), true);
@@ -579,9 +579,25 @@ BOOST_FIXTURE_TEST_CASE(comments_cashout_time_test, golos_publication_tester) tr
 
     BOOST_TEST_MESSAGE("--- checking that closed message comment was closed.");
     produce_block();
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_EQUAL(post.get_message({N(jackiechan), "sorry-guys-i-am-late"}).is_null(), true);
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(comments_closing, golos_publication_tester) try {
+    BOOST_TEST_MESSAGE("comments_closing");
+    init();
+    auto need_blocks = seconds_to_blocks(post.window);
+
+    BOOST_TEST_MESSAGE("--- checking that creating message triggers closing");
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(brucelee), "permlink"}));
+    produce_blocks(need_blocks);
+    BOOST_CHECK_EQUAL(success(), post.create_msg({N(chucknorris), "permlink"}));
+    produce_block();
+    BOOST_CHECK_EQUAL(post.get_message({N(brucelee), "permlink"}).is_null(), true);
+
+    BOOST_TEST_MESSAGE("--- checking that creating message triggers closing");
 
 } FC_LOG_AND_RETHROW()
 
@@ -763,7 +779,7 @@ BOOST_FIXTURE_TEST_CASE(set_max_payout, golos_publication_tester) try {
 
     BOOST_TEST_MESSAGE("--- checking max_payout cannot be changed after message closed");
     produce_blocks(seconds_to_blocks(post.window));
-    BOOST_CHECK_EQUAL(success(), post.closemssg());
+    BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
     BOOST_CHECK_EQUAL(err.no_message, post.set_max_payout({N(brucelee), "permlink"}, token.make_asset(1000)));
 


### PR DESCRIPTION
Resolves #773

Done:

- _(note)_ Scope of message-table made global.
- `cancel_messages()` is sending in transactions with recursive rescheduling.
- `cancel_messages()` logic is optimized - firstly modify messages and next modify pools, not update pool-table for each message.
- Tests proceeding.
- Documentation.

Planning TODOs:
- Add a bit tests.
- Fix python scripts.
- Some miscs.