### PR TITLE
Changes for bandwidth on gls with delegate bw. #774

### DIFF
--- a/genesis/genesis-info.json.tmpl
+++ b/genesis/genesis-info.json.tmpl
@@ -338,6 +338,15 @@
                 "update_auth_period": {"period":300}
             }}]
         },{
+            "code": "gls.ctrl",
+            "table": "msigauths",
+            "abi_type": "msig_auths",
+            "rows": [{"scope":"gls.ctrl", "payer": "gls.ctrl", "pk": 10816735270133563392, "data": {
+                "id": 10816735270133563392,
+                "witnesses": ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""],
+                "last_update": "2001-01-21T12:00:00.000"
+            }}]
+        },{
             "code": "gls.publish",
             "table": "pstngparams",
             "abi_type": "posting_state",

--- a/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
+++ b/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
@@ -75,8 +75,9 @@ public:
 
 private:
     ctrl_params_singleton _cfg;
-    ctrl_state props() {
-        return _cfg.get();
+    const ctrl_state& props() {
+        static const ctrl_state cfg = _cfg.get();
+        return cfg;
     }
     void assert_started();
 

--- a/golos.emit/include/golos.emit/golos.emit.hpp
+++ b/golos.emit/include/golos.emit/golos.emit.hpp
@@ -34,6 +34,11 @@ private:
     state_singleton _state;
     emit_params_singleton _cfg;
 
+    const emit_state& cfg() {
+        static const emit_state cfg = _cfg.get();
+        return cfg;
+    }
+
     void schedule_next(state& s, uint32_t delay);
 };
 


### PR DESCRIPTION
Changes for #774:
- Add bandwidth provider for all pools in gls.emit
- Don't change payer on modify objects in gls.publish
- Don't change payer on modify objects in gls.ctrl
- Add start state for cache of msig account in gls.ctrl