### PR TITLE
Allow adding referrals to gls, instead of referrer #763

### DIFF
--- a/golos.referral/src/golos.referral.cpp
+++ b/golos.referral/src/golos.referral.cpp
@@ -39,7 +39,7 @@ void referral::setparams(std::vector<referral_params> params) {
 
 void referral::addreferral(name referrer, name referral, uint32_t percent,
                            uint64_t expire, asset breakout) {
-    require_auth(referrer);
+    require_auth(_self);
 
     closeoldref();
 
@@ -61,7 +61,7 @@ void referral::addreferral(name referrer, name referral, uint32_t percent,
     eosio::check(breakout <= cfg.get().breakout_params.max_breakout, "breakout > max_breakout");
     eosio::check(percent  <= cfg.get().percent_params.max_percent, "specified parameter is greater than limit");
  
-    referrals.emplace(referrer, [&]( auto &item ) {
+    referrals.emplace(_self, [&]( auto &item ) {
         item.referral = referral;
         item.referrer = referrer;
         item.percent  = percent;

--- a/tests/golos.referral_test_api.hpp
+++ b/tests/golos.referral_test_api.hpp
@@ -21,7 +21,7 @@ struct golos_referral_api: base_contract_api {
 
     //// referral actions
      action_result create_referral(name referrer, name referral, uint32_t percent, uint64_t expire, asset breakout) {
-         return push(N(addreferral), referrer, args()
+         return push(N(addreferral), _code, args()
              ("referrer", referrer)
              ("referral", referral)
              ("percent", percent)


### PR DESCRIPTION
Resolves #763
Done:

- action `addreferral` can be issued only by `_self`
- payer for creating referral record is `_self`