### PR TITLE
Remove assert checking pool rshares >= 0 #814

### DIFF
--- a/golos.publication/golos.publication.cpp
+++ b/golos.publication/golos.publication.cpp
@@ -600,7 +600,6 @@ void publication::close_messages(name payer) {
             auto rsharesfn = wdfp_t(sharesfn);
             auto new_rsharesfn = WP(state.rsharesfn) - rsharesfn;
 
-            eosio::check(new_rshares >= 0, "LOGIC ERROR! publication::payrewards: new_rshares < 0");
             eosio::check(new_rsharesfn >= 0, "LOGIC ERROR! publication::payrewards: new_rsharesfn < 0");
 
             state.rshares = new_rshares.data();


### PR DESCRIPTION
Resolves #814.

This bug is old. From time when `close_messages` was `close_message`.