### PR TITLE
Fix referral when min/max-breakouts equal + del delay_param #820

### DIFF
--- a/docs/en-US/golos.referral_contract.md
+++ b/docs/en-US/golos.referral_contract.md
@@ -12,8 +12,7 @@ referral_param, types:[
         asset max_breakout
     },
     expire_parametrs (uint64_t max_expire),
-    percent_parametrs (uint32_t max_percent),
-    delay_parametrs (uint32_t delay_clear_old_ref)
+    percent_parametrs (uint16_t max_percent)
 ]
 ```
 
@@ -23,8 +22,7 @@ referral_param, types:[
     * `max_breakout` — the maximum allowable number of tokens required for the redemption of the referral account and, accordingly, the termination of the referral program.
   * `expire_parametrs `— the maximum allowable time of the referral program.
   * `percent_parametrs` — maximum allowable percentage of deduction to the referrer during the duration of the referral program.
-  * `delay_parametrs` — period of time (mentioned in seconds) after which the action to delete obsolete entries from the table is launched.
-
+  
 
 ## Actions used in golos.referral smart contract
 
@@ -35,7 +33,7 @@ The `setparams` action is used to set (configure) the parameters of a smart cont
 ```cpp
 void referral::setparams(std::vector<referral_params> params)
 ``` 
- The parameter `params`is a value in the form of a structure which contains the fields: `breakout_parametrs`, `expire_parametrs`, `percent_parametrs`, `delay_parametrs`.  
+ The parameter `params`is a value in the form of a structure which contains the fields: `breakout_parametrs`, `expire_parametrs`, `percent_parametrs`.
 
 
 ## validateprms
@@ -51,7 +49,7 @@ This action comes in the following the form:
 void referral::addreferral(
     name referrer,
     name referral,
-    uint32_t percent,
+    uint16_t percent,
     uint64_t expire,
     asset breakout
 )

--- a/docs/ru-RU/golos.referral_contract.md
+++ b/docs/ru-RU/golos.referral_contract.md
@@ -13,8 +13,7 @@ referral_param, types:[
         asset max_breakout
     },
     expire_parametrs (uint64_t max_expire),
-    percent_parametrs (uint32_t max_percent),
-    delay_parametrs (uint32_t delay_clear_old_ref)
+    percent_parametrs (uint16_t max_percent)
 ]
 ```
 Параметры:  
@@ -24,7 +23,6 @@ referral_param, types:[
 
 `expire_parametrs` — максимально допустимое время действия реферальной программы;  
 `percent_parametrs` — максимально допустимый процент отчисления рефереру в течение действия реферальной программы;  
-`delay_parametrs` — период времени (в секундах), через который запускается действие по удалению устаревших записей из таблицы.  
 
 ## Операции-действия, применяемые в смарт-контракте golos.referreal
 В смарт-контракте `golos.referral` реализованы следующие операции-действия: [setparams](#operaciya-deistvie-setparams), [validateprms](#operaciya-deistvie-validateprms), [addreferral](#operaciya-deistvie-addreferral), [closeoldref](#operaciya-deistvie-closeoldref).  
@@ -34,7 +32,7 @@ referral_param, types:[
 ```cpp
 void referral::setparams(std::vector<referral_params> params)
 ```
-Параметр `params` — значение в виде структуры. Настраиваемые параметры: `breakout_parametrs`, `expire_parametrs`, `percent_parametrs`, `delay_parametrs`. 
+Параметр `params` — значение в виде структуры. Настраиваемые параметры: `breakout_parametrs`, `expire_parametrs`, `percent_parametrs`.
 
 ## Операция-действие validateprms
 Операция-действие `validateprms` вызывается смарт-контрактом и используется для проверки параметров на валидность, контролирует наличие в них ошибок. 
@@ -49,7 +47,7 @@ void referral::validateprms(std::vector<referral_params> params)
 void referral::addreferral(
     name referrer,
     name referral,
-    uint32_t percent,
+    uint16_t percent,
     uint64_t expire,
     asset breakout
 )

--- a/genesis/genesis-info.json.tmpl
+++ b/genesis/genesis-info.json.tmpl
@@ -408,10 +408,9 @@
             "abi_type": "referral_state",
             "rows": [{"scope": "gls.referral", "payer": "gls.referral", "pk": 13445306870675800064, "data": {
                 "id": 13445306870675800064,
-                "breakout_params": {"min_breakout":"10000.000 GOLOS", "max_breakout":"100000.000 GOLOS"},
-                "expire_params": {"max_expire":604800},
-                "percent_params": {"max_percent":5000},
-                "delay_params": {"delay_clear_old_ref":84600}
+                "breakout_params": {"min_breakout":"0.001 GOLOS", "max_breakout":"100.000 GOLOS"},
+                "percent_params": {"max_percent":1000},
+                "expire_params": {"max_expire":15552000}
             }}]
         },{
             "code": "gls.charge",

--- a/golos.referral/abi/golos.referral.abi
+++ b/golos.referral/abi/golos.referral.abi
@@ -6,8 +6,7 @@
           "types": [
                 "breakout_parametrs",
                 "expire_parametrs",
-                "percent_parametrs",
-                "delay_parametrs"
+                "percent_parametrs"
             ]
         }
     ],
@@ -18,7 +17,7 @@
             "fields": [
                 {"type": "name", "name": "referrer"},
                 {"type": "name", "name": "referral"},
-                {"type": "uint32", "name": "percent"},
+                {"type": "uint16", "name": "percent"},
                 {"type": "uint64", "name": "expire"},
                 {"type": "asset", "name": "breakout"}
             ]
@@ -42,14 +41,7 @@
            "name": "percent_parametrs",
            "base": "",
            "fields": [
-              {"name": "max_percent", "type": "uint32"}
-           ]
-        },
-        {
-           "name": "delay_parametrs",
-           "base": "",
-           "fields": [
-              {"name": "delay_clear_old_ref", "type": "uint32"}
+              {"name": "max_percent", "type": "uint16"}
            ]
         },
         {
@@ -59,8 +51,7 @@
               {"name": "id", "type": "uint64"},
               {"name": "breakout_params", "type": "breakout_parametrs"},
               {"name": "expire_params",   "type": "expire_parametrs"},
-              {"name": "percent_params",  "type": "percent_parametrs"},
-              {"name": "delay_params",    "type": "delay_parametrs"}
+              {"name": "percent_params",  "type": "percent_parametrs"}
            ]
         },
         {

--- a/golos.referral/include/golos.referral/golos.referral.hpp
+++ b/golos.referral/include/golos.referral/golos.referral.hpp
@@ -18,7 +18,7 @@ public:
     void setparams(std::vector<referral_params> params);
 
     [[eosio::action]]
-    void addreferral(name referrer, name referral, uint32_t percent, uint64_t expire, asset breakout);
+    void addreferral(name referrer, name referral, uint16_t percent, uint64_t expire, asset breakout);
 
     [[eosio::action]]
     void closeoldref();
@@ -29,7 +29,7 @@ private:
     struct obj_referral {
         name referrer;
         name referral;
-        uint32_t percent;
+        uint16_t percent;
         uint64_t expire;
         asset breakout;
 
@@ -47,16 +47,15 @@ private:
                             eosio::indexed_by< "expirekey"_n, eosio::const_mem_fun<obj_referral, uint64_t, &obj_referral::expire_key> > >;
 
 public:
-    static inline obj_referral account_referrer( name contract_name, name referral ) {
-        referrals_table referrals( contract_name, contract_name.value );
-        auto itr = referrals.find( referral.value );
+    static inline obj_referral account_referrer(name contract_name, name referral) {
+        referrals_table referrals(contract_name, contract_name.value);
+        auto itr = referrals.find(referral.value);
         if (itr != referrals.end()) {
             const auto now = static_cast<uint64_t>(eosio::current_time_point().sec_since_epoch());
             if (itr->expire >= now) {
                 return *itr;
             }
         }
-
         return obj_referral();
     }
 

--- a/golos.referral/include/golos.referral/parameters.hpp
+++ b/golos.referral/include/golos.referral/parameters.hpp
@@ -10,35 +10,36 @@ namespace golos {
 using namespace eosio;
 
 struct breakout_parametrs : parameter {
-   asset min_breakout;
-   asset max_breakout;
+    asset min_breakout;
+    asset max_breakout;
 
-   void validate() const override {
+    void validate() const override {
         eosio::check(min_breakout <= max_breakout, "min_breakout > max_breakout");
         eosio::check(min_breakout.amount >= 0, "min_breakout < 0");
-      return (obj.max_breakout.symbol != other.max_breakout.symbol) ||
-             (obj.min_breakout.symbol != other.min_breakout.symbol) ||
-             (obj.min_breakout.amount != other.min_breakout.amount) ||
-             (obj.min_breakout.amount != other.min_breakout.amount); 
-   }
         // max_breakout is already non-negative here
     }
 
     static bool not_equal(const breakout_parametrs& obj, const breakout_parametrs& other) {
+        return
+            (obj.max_breakout.symbol != other.max_breakout.symbol) ||
+            (obj.min_breakout.symbol != other.min_breakout.symbol) ||
+            (obj.min_breakout.amount != other.min_breakout.amount) ||
+            (obj.min_breakout.amount != other.min_breakout.amount);
+    }
 };
 using breakout_param = param_wrapper<breakout_parametrs,2>;
 
 struct expire_parametrs : parameter {
-   uint64_t max_expire;
+    uint64_t max_expire;
 };
 using expire_param = param_wrapper<expire_parametrs,1>;
 
 struct percent_parametrs : parameter {
     uint16_t max_percent;
 
-   void validate() const override {
+    void validate() const override {
         eosio::check(max_percent <= 10000, "max_percent > 100.00%");
-   }
+    }
 };
 using percent_param = param_wrapper<percent_parametrs,1>;
 

--- a/golos.referral/include/golos.referral/parameters.hpp
+++ b/golos.referral/include/golos.referral/parameters.hpp
@@ -16,27 +16,25 @@ struct breakout_parametrs : parameter {
    void validate() const override {
         eosio::check(min_breakout <= max_breakout, "min_breakout > max_breakout");
         eosio::check(min_breakout.amount >= 0, "min_breakout < 0");
-        eosio::check(max_breakout.amount >= 0, "max_breakout < 0");
-   }
-
-   static bool compare(const breakout_parametrs& obj, const breakout_parametrs& other) {
       return (obj.max_breakout.symbol != other.max_breakout.symbol) ||
              (obj.min_breakout.symbol != other.min_breakout.symbol) ||
              (obj.min_breakout.amount != other.min_breakout.amount) ||
              (obj.min_breakout.amount != other.min_breakout.amount); 
    }
+        // max_breakout is already non-negative here
+    }
+
+    static bool not_equal(const breakout_parametrs& obj, const breakout_parametrs& other) {
 };
 using breakout_param = param_wrapper<breakout_parametrs,2>;
 
 struct expire_parametrs : parameter {
    uint64_t max_expire;
-
-   void validate() const override {}
 };
 using expire_param = param_wrapper<expire_parametrs,1>;
 
 struct percent_parametrs : parameter {
-   uint32_t max_percent;
+    uint16_t max_percent;
 
    void validate() const override {
         eosio::check(max_percent <= 10000, "max_percent > 100.00%");
@@ -44,22 +42,14 @@ struct percent_parametrs : parameter {
 };
 using percent_param = param_wrapper<percent_parametrs,1>;
 
-struct delay_parametrs : parameter {
-   uint32_t delay_clear_old_ref;
-
-   void validate() const override {}
-};
-using delay_param = param_wrapper<delay_parametrs,1>;
-
-using referral_params = std::variant<breakout_param, expire_param, percent_param, delay_param>;
+using referral_params = std::variant<breakout_param, expire_param, percent_param>;
 
 struct [[eosio::table]] referral_state {
     breakout_param breakout_params;
     expire_param   expire_params;
     percent_param  percent_params;
-    delay_param    delay_params;
 
-    static constexpr int params_count = 4;
+    static constexpr int params_count = 3;
 };
 using referral_params_singleton = eosio::singleton<"refparams"_n, referral_state>;
 

--- a/golos.referral/src/golos.referral.cpp
+++ b/golos.referral/src/golos.referral.cpp
@@ -10,9 +10,9 @@ using namespace eosio;
 struct referral_params_setter: set_params_visitor<referral_state> {
     using set_params_visitor::set_params_visitor; // enable constructor
 
-   bool operator()(const breakout_param& p) {
-       return set_param(p, &referral_state::breakout_params, &breakout_param::compare);
-   }
+    bool operator()(const breakout_param& p) {
+        return set_param(p, &referral_state::breakout_params, &breakout_param::not_equal);
+    }
 
     bool operator()(const expire_param& p) {
        return set_param(p, &referral_state::expire_params);
@@ -20,10 +20,6 @@ struct referral_params_setter: set_params_visitor<referral_state> {
 
     bool operator()(const percent_param& p) {
        return set_param(p, &referral_state::percent_params);
-   }
-
-    bool operator()(const delay_param& p) {
-       return set_param(p, &referral_state::delay_params);
    }
 };
 
@@ -37,17 +33,15 @@ void referral::setparams(std::vector<referral_params> params) {
     param_helper::set_parameters<referral_params_setter>(params, cfg, _self);
 }
 
-void referral::addreferral(name referrer, name referral, uint32_t percent,
-                           uint64_t expire, asset breakout) {
+void referral::addreferral(name referrer, name referral, uint16_t percent, uint64_t expire, asset breakout) {
     require_auth(_self);
 
     closeoldref();
 
+    eosio::check(referrer != referral, "referral can not be referrer");
     referrals_table referrals(_self, _self.value);
     auto it_referral = referrals.find(referral.value);
     eosio::check(it_referral == referrals.end(), "A referral with the same name already exists");
-
-    eosio::check(referrer != referral, "referral can not be referrer");
 
     referral_params_singleton cfg(_self, _self.value);
     eosio::check(cfg.exists(), "not found parametrs");
@@ -55,9 +49,9 @@ void referral::addreferral(name referrer, name referral, uint32_t percent,
     const auto now = eosio::current_time_point();
     const auto min_expire = now.sec_since_epoch();
     const auto max_expire = (now + eosio::seconds(cfg.get().expire_params.max_expire)).sec_since_epoch();
-    eosio::check(expire   >  min_expire, "expire < current block time");
+    eosio::check(expire   >  min_expire, "expire <= current block time");
     eosio::check(expire   <= max_expire, "expire > current block time + max_expire");
-    eosio::check(breakout >  cfg.get().breakout_params.min_breakout, "breakout <= min_breakout");
+    eosio::check(breakout >= cfg.get().breakout_params.min_breakout, "breakout < min_breakout");
     eosio::check(breakout <= cfg.get().breakout_params.max_breakout, "breakout > max_breakout");
     eosio::check(percent  <= cfg.get().percent_params.max_percent, "specified parameter is greater than limit");
  
@@ -90,18 +84,16 @@ void referral::on_transfer(name from, name to, asset quantity, std::string memo)
 
 void referral::closeoldref() {
     referral_params_singleton cfg(_self, _self.value);
-    eosio::check(cfg.exists(), "not found parametrs");
+    eosio::check(cfg.exists(), "referral: parametrs not found");
 
-    referrals_table referrals(_self, _self.value);
+    referrals_table referrals(_self, _self.value);  // NOTE: can be cached to not recreate in calling actions
     const auto now = static_cast<uint64_t>(eosio::current_time_point().sec_since_epoch());
-    auto index_expire = referrals.get_index<"expirekey"_n>();
-    auto it_index_expire = index_expire.begin();
-    int  i = 0;
-    while ( it_index_expire != index_expire.end() ) {
-        if (++i > config::max_deletions_per_trx || it_index_expire->expire >= now) {
-            break;
-        }
-        it_index_expire = index_expire.erase(it_index_expire);
+    auto idx = referrals.get_index<"expirekey"_n>();
+    auto itr = idx.begin();
+    int  i = config::max_deletions_per_trx;
+    while (itr != idx.end() && i > 0 && itr->expire < now) {
+        itr = idx.erase(itr);
+        i--;
     }
 }
 

--- a/golos.referral/src/golos.referral.cpp
+++ b/golos.referral/src/golos.referral.cpp
@@ -15,12 +15,12 @@ struct referral_params_setter: set_params_visitor<referral_state> {
     }
 
     bool operator()(const expire_param& p) {
-       return set_param(p, &referral_state::expire_params);
-   }
+        return set_param(p, &referral_state::expire_params);
+    }
 
     bool operator()(const percent_param& p) {
-       return set_param(p, &referral_state::percent_params);
-   }
+        return set_param(p, &referral_state::percent_params);
+    }
 };
 
 void referral::validateprms(std::vector<referral_params> params) {
@@ -54,8 +54,8 @@ void referral::addreferral(name referrer, name referral, uint16_t percent, uint6
     eosio::check(breakout >= cfg.get().breakout_params.min_breakout, "breakout < min_breakout");
     eosio::check(breakout <= cfg.get().breakout_params.max_breakout, "breakout > max_breakout");
     eosio::check(percent  <= cfg.get().percent_params.max_percent, "specified parameter is greater than limit");
- 
-    referrals.emplace(_self, [&]( auto &item ) {
+
+    referrals.emplace(_self, [&](auto &item) {
         item.referral = referral;
         item.referrer = referrer;
         item.percent  = percent;
@@ -65,7 +65,7 @@ void referral::addreferral(name referrer, name referral, uint16_t percent, uint6
 }
 
 void referral::on_transfer(name from, name to, asset quantity, std::string memo) {
-    if(_self != to)
+    if (_self != to)
         return;
 
     closeoldref();
@@ -74,7 +74,7 @@ void referral::on_transfer(name from, name to, asset quantity, std::string memo)
     auto it_referral = referrals.find(from.value);
     eosio::check(it_referral != referrals.end(), "A referral with this name doesn't exist.");
     eosio::check(it_referral->breakout.amount == quantity.amount, "Amount of funds doesn't equal.");
-    
+
     INLINE_ACTION_SENDER(token, transfer)
         (config::token_name, {_self, config::code_name},
         {_self, it_referral->referrer, quantity, ""});

--- a/scripts/golos-boot-sequence/golos-boot-sequence.py
+++ b/scripts/golos-boot-sequence/golos-boot-sequence.py
@@ -369,10 +369,9 @@ def createCommunity():
             ]]) + '-p gls.ctrl')
 
         retry(args.cleos + 'push action gls.referral setparams ' + jsonArg([[
-            ['breakout_parametrs', {'min_breakout': intToToken(10000), 'max_breakout': intToToken(100000)}],
-            ['expire_parametrs', {'max_expire': 7*24*3600}],  # sec
-            ['percent_parametrs', {'max_percent': 5000}],     # 50.00%
-            ['delay_parametrs', {'delay_clear_old_ref': 1*24*3600}] # sec
+            ['breakout_parametrs', {'min_breakout': "0.001 %s" % args.symbol, 'max_breakout': intToToken(100)}],
+            ['percent_parametrs', {'max_percent': 1000}],     # 10.00%
+            ['expire_parametrs', {'max_expire': 6*30*24*3600}]  # sec
         ]]) + '-p gls.referral')
 
 def createWitnessAccounts():

--- a/tests/golos.referral_test_api.hpp
+++ b/tests/golos.referral_test_api.hpp
@@ -20,15 +20,15 @@ struct golos_referral_api: base_contract_api {
     }
 
     //// referral actions
-     action_result create_referral(name referrer, name referral, uint32_t percent, uint64_t expire, asset breakout) {
-         return push(N(addreferral), _code, args()
-             ("referrer", referrer)
-             ("referral", referral)
-             ("percent", percent)
-             ("expire", expire)
-             ("breakout", breakout)
-         );
-     }
+    action_result create_referral(name referrer, name referral, uint16_t percent, uint64_t expire, asset breakout) {
+        return push(N(addreferral), _code, args()
+            ("referrer", referrer)
+            ("referral", referral)
+            ("percent", percent)
+            ("expire", expire)
+            ("breakout", breakout)
+        );
+    }
 
      action_result close_old_referrals() {
          return push(N(closeoldref), _code, args());
@@ -59,13 +59,10 @@ struct golos_referral_api: base_contract_api {
          return string("['expire_parametrs', {'max_expire':'") + std::to_string(max_expire) + "'}]";
      }
 
-     string percent_parametrs(uint32_t max_percent) {
-         return string("['percent_parametrs', {'max_percent':'") + std::to_string(max_percent) + "'}]";
-     }
 
-     string delay_parametrs(uint32_t delay_clear_old_ref) {
-         return string("['delay_parametrs', {'delay_clear_old_ref':'") + std::to_string(delay_clear_old_ref) + "'}]";
-     }
+    string percent_parametrs(uint16_t max_percent) {
+        return string("['percent_parametrs', {'max_percent':'") + std::to_string(max_percent) + "'}]";
+    }
 };
 
 

--- a/tests/golos.referral_test_api.hpp
+++ b/tests/golos.referral_test_api.hpp
@@ -30,35 +30,34 @@ struct golos_referral_api: base_contract_api {
         );
     }
 
-     action_result close_old_referrals() {
-         return push(N(closeoldref), _code, args());
-     }
+    action_result close_old_referrals() {
+        return push(N(closeoldref), _code, args());
+    }
 
-     action_result set_params(name creator, std::string json_params) {
-         return push(N(setparams), creator, args()
-             ("params", json_str_to_obj(json_params)));
-     }
+    action_result set_params(name creator, std::string json_params) {
+        return push(N(setparams), creator, args()
+            ("params", json_str_to_obj(json_params)));
+    }
 
-     variant get_params() const {
-         return base_contract_api::get_struct(_code, N(refparams), N(refparams), "referral_state");
-     }
+    variant get_params() const {
+        return base_contract_api::get_struct(_code, N(refparams), N(refparams), "referral_state");
+    }
 
     variant get_referral(name referral) {
         return _tester->get_chaindb_struct(_code, _code, N(referrals), referral, "obj_referral");
     }
 
-     vector<variant> get_referrals() {
-         return _tester->get_all_chaindb_rows(_code, _code, N(referrals), false);
-     }
+    vector<variant> get_referrals() {
+        return _tester->get_all_chaindb_rows(_code, _code, N(referrals), false);
+    }
 
-     string breakout_parametrs(asset min_breakout, asset max_breakout) {
-         return string("['breakout_parametrs', {'min_breakout':'") + min_breakout.to_string() + "','max_breakout':'" + max_breakout.to_string() + "'}]";
-     }
+    string breakout_parametrs(asset min_breakout, asset max_breakout) {
+        return string("['breakout_parametrs', {'min_breakout':'") + min_breakout.to_string() + "','max_breakout':'" + max_breakout.to_string() + "'}]";
+    }
 
-     string expire_parametrs(uint64_t max_expire) {
-         return string("['expire_parametrs', {'max_expire':'") + std::to_string(max_expire) + "'}]";
-     }
-
+    string expire_parametrs(uint64_t max_expire) {
+        return string("['expire_parametrs', {'max_expire':'") + std::to_string(max_expire) + "'}]";
+    }
 
     string percent_parametrs(uint16_t max_percent) {
         return string("['percent_parametrs', {'max_percent':'") + std::to_string(max_percent) + "'}]";

--- a/tests/golos.referral_tests.cpp
+++ b/tests/golos.referral_tests.cpp
@@ -51,9 +51,8 @@ public:
         auto breakout_parametrs = referral.breakout_parametrs(min_breakout, max_breakout);
         auto expire_parametrs   = referral.expire_parametrs(max_expire);
         auto percent_parametrs  = referral.percent_parametrs(max_percent);
-        auto delay_parametrs    = referral.delay_parametrs(delay_clear_old_ref);
 
-        auto params = "[" + breakout_parametrs + "," + expire_parametrs + "," + percent_parametrs + "," + delay_parametrs + "]";
+        auto params = "[" + breakout_parametrs + "," + expire_parametrs + "," + percent_parametrs + "]";
         BOOST_CHECK_EQUAL(success(), referral.set_params(cfg::referral_name, params));
     }
 
@@ -88,16 +87,15 @@ protected:
     struct errors: contract_error_messages {
         const string referral_exist = amsg("A referral with the same name already exists");
         const string referral_equal = amsg("referral can not be referrer");
-        const string min_expire     = amsg("expire < current block time");
+        const string min_expire     = amsg("expire <= current block time");
         const string max_expire     = amsg("expire > current block time + max_expire");
-        const string min_breakout   = amsg("breakout <= min_breakout");
+        const string min_breakout   = amsg("breakout < min_breakout");
         const string max_breakout   = amsg("breakout > max_breakout");
         const string persent        = amsg("specified parameter is greater than limit");
 
         const string min_more_than_max = amsg("min_breakout > max_breakout");
         const string negative_minimum  = amsg("min_breakout < 0");
-        const string negative_maximum  = amsg("max_breakout < 0");
-        const string limit_persent     = amsg("max_percent > 100.00%");
+        const string limit_percent     = amsg("max_percent > 100.00%");
 
         const string referral_not_exist      = amsg("A referral with this name doesn't exist.");
         const string funds_not_equal   = amsg("Amount of funds doesn't equal.");
@@ -113,8 +111,7 @@ protected:
     const asset min_breakout = token.make_asset(10);
     const asset max_breakout = token.make_asset(100);
     const uint64_t max_expire = 600; // 600 sec
-    const uint32_t max_percent = 5000; // 50.00%
-    const uint32_t delay_clear_old_ref = 650; // 650 sec
+    const uint16_t max_percent = 5000; // 50.00%
 
     std::vector<account_name> _users;
     };
@@ -137,7 +134,7 @@ BOOST_AUTO_TEST_SUITE(golos_referral_tests)
      BOOST_TEST_CHECK(obj_params["breakout_params"]["min_breakout"].as<asset>() == min_breakout);
      BOOST_TEST_CHECK(obj_params["breakout_params"]["max_breakout"].as<asset>() == max_breakout);
      BOOST_TEST_CHECK(obj_params["expire_params"]["max_expire"].as<uint64_t>() == max_expire);
-     BOOST_TEST_CHECK(obj_params["percent_params"]["max_percent"].as<uint32_t>() == max_percent);
+    BOOST_TEST_CHECK(obj_params["percent_params"]["max_percent"].as<uint16_t>() == max_percent);
 
      auto params = "[" + referral.breakout_parametrs(max_breakout, min_breakout) + "]";
      BOOST_CHECK_EQUAL(err.min_more_than_max, referral.set_params(cfg::referral_name, params));
@@ -146,7 +143,7 @@ BOOST_AUTO_TEST_SUITE(golos_referral_tests)
      BOOST_CHECK_EQUAL(err.negative_minimum, referral.set_params(cfg::referral_name, params));
 
      params = "[" + referral.percent_parametrs(10001) + "]";
-     BOOST_CHECK_EQUAL(err.limit_persent, referral.set_params(cfg::referral_name, params));
+    BOOST_CHECK_EQUAL(err.limit_percent, referral.set_params(cfg::referral_name, params));
 
  } FC_LOG_AND_RETHROW()
 
@@ -155,14 +152,13 @@ BOOST_AUTO_TEST_SUITE(golos_referral_tests)
 
      init_params();
      produce_blocks();
+    const auto current_time = control->head_block_time().sec_since_epoch();
 
-     auto time_now = static_cast<uint32_t>(time(nullptr));
-     const auto current_time = control->head_block_time().sec_since_epoch();
+    BOOST_TEST_MESSAGE("-- fail on bad params");
+    BOOST_CHECK_EQUAL(err.referral_equal, referral.create_referral(N(issuer), N(issuer), 500, 0, token.make_asset(10)));
 
-     BOOST_CHECK_EQUAL(err.referral_equal, referral.create_referral(N(issuer), N(issuer), time_now, 0, token.make_asset(10)));
-
-     BOOST_CHECK_EQUAL(err.min_expire, referral.create_referral(N(issuer), N(sania), time_now, 0, token.make_asset(10)));
-     BOOST_CHECK_EQUAL(err.max_expire, referral.create_referral(N(issuer), N(sania), time_now + 5 /*5 sec*/, 999999999999, token.make_asset(10)));
+    BOOST_CHECK_EQUAL(err.min_expire, referral.create_referral(N(issuer), N(sania), 500, 0, token.make_asset(10)));
+    BOOST_CHECK_EQUAL(err.max_expire, referral.create_referral(N(issuer), N(sania), 500, 999999999999, token.make_asset(10)));
 
      auto expire = 8; // sec
      BOOST_CHECK_EQUAL(err.min_breakout, referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(0)));
@@ -171,9 +167,15 @@ BOOST_AUTO_TEST_SUITE(golos_referral_tests)
      BOOST_CHECK_EQUAL(err.persent, referral.create_referral(N(issuer), N(sania), 9500, current_time + expire, token.make_asset(50)));
 
      BOOST_CHECK_EQUAL(success(), referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(50)));
+    BOOST_TEST_MESSAGE("-- fail on re-creating referral");
 
      produce_blocks();
      BOOST_CHECK_EQUAL(err.referral_exist, referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(50)));
+    BOOST_TEST_MESSAGE("-- success with fixed breakout");
+    auto params = "[" + referral.breakout_parametrs(max_breakout, max_breakout) + "]";
+    BOOST_CHECK_EQUAL(success(), referral.set_params(cfg::referral_name, params));
+    BOOST_CHECK_EQUAL(success(),
+        referral.create_referral(N(issuer), N(pasha), max_percent, current_time + expire, max_breakout));
 
  } FC_LOG_AND_RETHROW()
 
@@ -217,7 +219,7 @@ BOOST_FIXTURE_TEST_CASE(close_referral_tests, golos_referral_tester) try {
 
     init_params();
 
-    const auto expire = 8; // sec
+    const auto expire = 9; // sec
     const auto current_time = control->head_block_time().sec_since_epoch();
     BOOST_CHECK_EQUAL(success(), referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(50)));
     BOOST_CHECK_EQUAL(success(), referral.close_old_referrals());
@@ -228,11 +230,7 @@ BOOST_FIXTURE_TEST_CASE(close_referral_tests, golos_referral_tester) try {
     BOOST_CHECK_EQUAL(v_referrals.at(0)["referral"].as<name>(), N(sania));
     BOOST_CHECK_EQUAL(v_referrals.at(0)["referrer"].as<name>(), N(issuer));
 
-    produce_blocks( golos::seconds_to_blocks(delay_clear_old_ref) );
-    v_referrals = referral.get_referrals();
-    BOOST_CHECK_EQUAL(v_referrals.size(), 1);
-    produce_blocks();
-
+    produce_blocks(golos::seconds_to_blocks(expire));
     v_referrals = referral.get_referrals();
     BOOST_CHECK_EQUAL(v_referrals.size(), 1);
     BOOST_CHECK_EQUAL(success(), referral.close_old_referrals());

--- a/tests/golos.referral_tests.cpp
+++ b/tests/golos.referral_tests.cpp
@@ -78,7 +78,7 @@ public:
                 "," + social_acc + "," + referral_acc + "," + curators_prcnt + "," + bwprovider + "]";
         BOOST_CHECK_EQUAL(success(), post.set_params(params));
         produce_blocks();
-   }
+    }
 
 protected:
     symbol _sym;
@@ -118,40 +118,41 @@ protected:
 
 BOOST_AUTO_TEST_SUITE(golos_referral_tests)
 
- BOOST_FIXTURE_TEST_CASE(set_params, golos_referral_tester) try {
-     BOOST_TEST_MESSAGE("Test vesting parameters");
-     BOOST_TEST_MESSAGE("--- prepare");
-     produce_blocks();
+BOOST_FIXTURE_TEST_CASE(set_params, golos_referral_tester) try {
+    BOOST_TEST_MESSAGE("Test vesting parameters");
+    BOOST_TEST_MESSAGE("--- prepare");
+    produce_blocks();
 
-     BOOST_TEST_MESSAGE("--- check that global params not exist");
-     BOOST_TEST_CHECK(referral.get_params().is_null());
+    BOOST_TEST_MESSAGE("--- check that global params not exist");
+    BOOST_TEST_CHECK(referral.get_params().is_null());
 
-     init_params();
-     produce_blocks();
+    init_params();
+    produce_blocks();
 
-     auto obj_params = referral.get_params();
-     BOOST_TEST_MESSAGE("--- " + fc::json::to_string(obj_params));
-     BOOST_TEST_CHECK(obj_params["breakout_params"]["min_breakout"].as<asset>() == min_breakout);
-     BOOST_TEST_CHECK(obj_params["breakout_params"]["max_breakout"].as<asset>() == max_breakout);
-     BOOST_TEST_CHECK(obj_params["expire_params"]["max_expire"].as<uint64_t>() == max_expire);
+    auto obj_params = referral.get_params();
+    BOOST_TEST_MESSAGE("--- " + fc::json::to_string(obj_params));
+    BOOST_TEST_CHECK(obj_params["breakout_params"]["min_breakout"].as<asset>() == min_breakout);
+    BOOST_TEST_CHECK(obj_params["breakout_params"]["max_breakout"].as<asset>() == max_breakout);
+    BOOST_TEST_CHECK(obj_params["expire_params"]["max_expire"].as<uint64_t>() == max_expire);
     BOOST_TEST_CHECK(obj_params["percent_params"]["max_percent"].as<uint16_t>() == max_percent);
 
-     auto params = "[" + referral.breakout_parametrs(max_breakout, min_breakout) + "]";
-     BOOST_CHECK_EQUAL(err.min_more_than_max, referral.set_params(cfg::referral_name, params));
+    auto params = "[" + referral.breakout_parametrs(max_breakout, min_breakout) + "]";
+    BOOST_CHECK_EQUAL(err.min_more_than_max, referral.set_params(cfg::referral_name, params));
 
-     params = "[" + referral.breakout_parametrs(token.make_asset(-1), max_breakout) + "]";
-     BOOST_CHECK_EQUAL(err.negative_minimum, referral.set_params(cfg::referral_name, params));
+    params = "[" + referral.breakout_parametrs(token.make_asset(-1), max_breakout) + "]";
+    BOOST_CHECK_EQUAL(err.negative_minimum, referral.set_params(cfg::referral_name, params));
 
-     params = "[" + referral.percent_parametrs(10001) + "]";
+    params = "[" + referral.percent_parametrs(10001) + "]";
     BOOST_CHECK_EQUAL(err.limit_percent, referral.set_params(cfg::referral_name, params));
 
- } FC_LOG_AND_RETHROW()
+} FC_LOG_AND_RETHROW()
 
- BOOST_FIXTURE_TEST_CASE(create_referral_tests, golos_referral_tester) try {
-     BOOST_TEST_MESSAGE("Test creating referral");
+BOOST_FIXTURE_TEST_CASE(create_referral_tests, golos_referral_tester) try {
+    BOOST_TEST_MESSAGE("Test creating referral");
 
-     init_params();
-     produce_blocks();
+    init_params();
+    produce_blocks();
+
     const auto current_time = control->head_block_time().sec_since_epoch();
 
     BOOST_TEST_MESSAGE("-- fail on bad params");
@@ -160,29 +161,30 @@ BOOST_AUTO_TEST_SUITE(golos_referral_tests)
     BOOST_CHECK_EQUAL(err.min_expire, referral.create_referral(N(issuer), N(sania), 500, 0, token.make_asset(10)));
     BOOST_CHECK_EQUAL(err.max_expire, referral.create_referral(N(issuer), N(sania), 500, 999999999999, token.make_asset(10)));
 
-     auto expire = 8; // sec
-     BOOST_CHECK_EQUAL(err.min_breakout, referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(0)));
-     BOOST_CHECK_EQUAL(err.max_breakout, referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(110)));
+    auto expire = 8; // sec
+    BOOST_CHECK_EQUAL(err.min_breakout, referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(0)));
+    BOOST_CHECK_EQUAL(err.max_breakout, referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(110)));
 
-     BOOST_CHECK_EQUAL(err.persent, referral.create_referral(N(issuer), N(sania), 9500, current_time + expire, token.make_asset(50)));
+    BOOST_CHECK_EQUAL(err.persent, referral.create_referral(N(issuer), N(sania), 9500, current_time + expire, token.make_asset(50)));
 
-     BOOST_CHECK_EQUAL(success(), referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(50)));
+    BOOST_CHECK_EQUAL(success(), referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(50)));
+
     BOOST_TEST_MESSAGE("-- fail on re-creating referral");
+    produce_blocks();
+    BOOST_CHECK_EQUAL(err.referral_exist, referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(50)));
 
-     produce_blocks();
-     BOOST_CHECK_EQUAL(err.referral_exist, referral.create_referral(N(issuer), N(sania), 500, current_time + expire, token.make_asset(50)));
     BOOST_TEST_MESSAGE("-- success with fixed breakout");
     auto params = "[" + referral.breakout_parametrs(max_breakout, max_breakout) + "]";
     BOOST_CHECK_EQUAL(success(), referral.set_params(cfg::referral_name, params));
     BOOST_CHECK_EQUAL(success(),
         referral.create_referral(N(issuer), N(pasha), max_percent, current_time + expire, max_breakout));
 
- } FC_LOG_AND_RETHROW()
+} FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(transfer_tests, golos_referral_tester) try {
     BOOST_TEST_MESSAGE("Transfer testing");
-    
-    init_params(); 
+
+    init_params();
     const auto expire = 8;
     const auto breakout = 100;
 
@@ -213,7 +215,7 @@ BOOST_FIXTURE_TEST_CASE(transfer_tests, golos_referral_tester) try {
     BOOST_TEST_MESSAGE("--- checking that record about referral was removed");
     BOOST_CHECK(!referral.get_referral(N(vania)));
 } FC_LOG_AND_RETHROW()
-  
+
 BOOST_FIXTURE_TEST_CASE(close_referral_tests, golos_referral_tester) try {
     BOOST_TEST_MESSAGE("Test close referral");
 
@@ -249,8 +251,8 @@ BOOST_FIXTURE_TEST_CASE(create_referral_message_tests, golos_referral_tester) tr
     BOOST_CHECK_EQUAL(success(), post.create_msg({N(sania), "permlink"}));
 
     auto post_sania = post.get_message({N(sania), "permlink"});
-    BOOST_CHECK_EQUAL (post_sania["beneficiaries"].size(), 1);
-    BOOST_CHECK_EQUAL( post_sania["beneficiaries"][uint8_t(0)].as<beneficiary>().account, N(issuer) );
+    BOOST_CHECK_EQUAL(post_sania["beneficiaries"].size(), 1);
+    BOOST_CHECK_EQUAL(post_sania["beneficiaries"][uint8_t(0)].as<beneficiary>().account, N(issuer));
 
     BOOST_CHECK_EQUAL(success(), referral.create_referral(N(issuer), N(pasha), 5000, current_time + expire, token.make_asset(50)));
     BOOST_CHECK_EQUAL(err.limit_percents, post.create_msg({N(pasha), "permlink"}, {N(), "parentprmlnk"}, { beneficiary{N(tania), 7000} }));
@@ -258,7 +260,7 @@ BOOST_FIXTURE_TEST_CASE(create_referral_message_tests, golos_referral_tester) tr
     BOOST_CHECK_EQUAL(success(), post.create_msg({N(pasha), "permlink"}, {N(), "parentprmlnk"}, { beneficiary{N(tania), 2000} }));
 
     auto post_pasha = post.get_message({N(pasha), "permlink"});
-    BOOST_CHECK_EQUAL (post_pasha["beneficiaries"].size(), 2);
+    BOOST_CHECK_EQUAL(post_pasha["beneficiaries"].size(), 2);
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
also:
+ fixes expire assert and add minor optimization (check input params before db access)
+ fixes wrong parameters (time as percent) in tests
+ sets referral params to values used in Golos #818
+ Documentation updated