### PR TITLE
Set genesis contracts params to values used in Golos #818

### DIFF
--- a/genesis/genesis-info.json.tmpl
+++ b/genesis/genesis-info.json.tmpl
@@ -22,29 +22,22 @@
             "curationfunc":{
                 "code":{
                     "varssize":1,
-                    "operators":[0,0,0,0,26,4,0,1,4],
-                    "values":[
-                        {"kind":0,"idx":0},
-                        {"kind":0,"idx":1},
-                        {"kind":1,"idx":0},
-                        {"kind":0,"idx":2},
-                        {"kind":0,"idx":3}],
-                    "nums":["9223372036854771712","16384000000000000",409,4096],
+                    "operators":[0],
+                    "values":[{"kind":1,"idx":0}],
+                    "nums":[],
                     "consts":[]
                 },
                 "maxarg":"9223372036854771712"
             },
             "timepenalty":{
                 "code":{
-                    "varssize":1,
-                    "operators":[0,0,4],
-                    "values":[
-                        {"kind":1,"idx":0},
-                        {"kind":0,"idx":0}],
-                    "nums":[7372800],
+                    "varssize":0,
+                    "operators":[0],
+                    "values":[{"kind":0,"idx":0}],
+                    "nums":[4096],
                     "consts":[]
                 },
-                "maxarg":7372800
+                "maxarg":4096
             },
             "maxtokenprop":5000
         },
@@ -151,7 +144,7 @@
 
 # NOTE: Technical account to start testnet and tests (remove from mainnet)
         {
-            "name": "tech", 
+            "name": "tech",
             "permissions": [{"name": "owner", "key": "INITIAL"}, {"name": "active", "key": "INITIAL"}],
             "sys_balance": "100000.0000 CYBER",
             "sys_staked": "100000.0000 CYBER",
@@ -295,11 +288,11 @@
             "abi_type": "emit_state",
             "rows": [{"scope":"gls.emit", "payer": "gls.emit", "pk": 6097199460613750784, "data": {
                 "id": 6097199460613750784,
-                "infrate": {"start":1500, "stop":95, "narrowing":250000},
+                "infrate": {"start":1399, "stop":95, "narrowing":250000},   # 1399 = 1515 - 29000000/250000
                 "pools": {"pools":[
                     {"name":"gls.ctrl", "percent":0},
-                    {"name":"gls.publish", "percent":6000},
-                    {"name":"gls.vesting", "percent":2400}]},
+                    {"name":"gls.publish", "percent":6667},
+                    {"name":"gls.vesting", "percent":2667}]},
                 "token": {"symbol":"3,GOLOS"},
                 "interval": {"value":900},
                 "bwprovider": {"actor":"gls","permission":"providebw"}
@@ -310,12 +303,18 @@
             "abi_type": "vesting_state",
             "rows": [{"scope":"GOLOS", "payer": "gls.vesting", "pk": 15758546561230307328, "data": {
                 "id": 15758546561230307328,
-                "withdraw": {"intervals":13, "interval_seconds":120},
-                "min_amount": {"min_amount":10000},
+                "withdraw": {"intervals":13, "interval_seconds":604800},
+                "min_amount": {"min_amount":10500000000},   # 3.0 GOLOS * 10 * 3500 gests
                 "delegation": {
-                    "min_amount":5000000,
-                    "min_remainder":15000000,
-                    "return_time":120,
+                    # median: 0.030 GOLOS and 0.010 GOLOS:
+                    #"min_amount":105000000,
+                    #"min_remainder":35000000,
+
+                    # increased to 1.000 GOLOS:
+                    "min_amount":3500000000,
+                    "min_remainder":3500000000,
+
+                    "return_time":604800,
                     "min_time":0,
                     "max_delegators":32},
                 "bwprovider": {"actor":"gls","permission":"providebw"}
@@ -349,12 +348,12 @@
             "rows": [{"scope":"gls.publish", "payer": "gls.publish", "pk": 12552436324427411456, "data": {
                 "id": 12552436324427411456,
                 "max_vote_changes": {"value":5},
-                "cashout_window": {"window":120, "upvote_lockout":15},
+                "cashout_window": {"window":604800, "upvote_lockout":60},
                 "max_beneficiaries": {"value":64},
                 "max_comment_depth": {"value":127},
                 "social_acc": {"value":"gls.social"},
                 "referral_acc": {"value":""},
-                "curators_prcnt": {"min_curators_prcnt":0, "max_curators_prcnt":9000},
+                "curators_prcnt": {"min_curators_prcnt":5000, "max_curators_prcnt":10000},
                 "bwprovider": {"actor":"gls","permission":"providebw"}
             }}]
         },{
@@ -428,7 +427,9 @@
                             "nums" : [1228800],
                             "consts" : [ ]
                         },
-                        "max_prev" : 922337203685477, "max_vesting" : 922337203685477, "max_elapsed" : 922337203685477
+                        "max_prev" : 9223372036854771712,
+                        "max_vesting" : 9223372036854771712,
+                        "max_elapsed" : 9223372036854771712
                     }
                 },{
                     "scope": "gls.charge", "payer": "gls", "pk": 91600047785730,
@@ -436,12 +437,14 @@
                             "charge_symbol" : 91600047785730, "token_code" : "GOLOS", "charge_id" : 2,
                             "func" : {
                             "varssize" : 3,
-                        "operators" : [0, 0, 4],
-                        "values" : [{"kind" : 1, "idx" : 2}, {"kind" : 0, "idx" : 0}],
-                        "nums" : [819200],
+                            "operators" : [0, 0, 4],
+                            "values" : [{"kind" : 1, "idx" : 2}, {"kind" : 0, "idx" : 0}],
+                            "nums" : [819200],
                             "consts" : [ ]
                         },
-                        "max_prev" : 922337203685477, "max_vesting" : 922337203685477, "max_elapsed" : 922337203685477
+                        "max_prev" : 9223372036854771712,
+                        "max_vesting" : 9223372036854771712,
+                        "max_elapsed" : 9223372036854771712
                     }
                 },{
                     "scope": "gls.charge", "payer": "gls", "pk": 91600047785728,
@@ -449,12 +452,14 @@
                         "charge_symbol" : 91600047785728, "token_code" : "GOLOS", "charge_id" : 0,
                         "func" : {
                             "varssize" : 3,
-                            "operators" : [0, 0, 0, 3, 4],
-                            "values" : [{"kind" : 1, "idx" : 2}, {"kind" : 0, "idx" : 0}, {"kind" : 0, "idx" : 1}],
-                            "nums" : [20480, 353894400],
+                            "operators" : [0, 0, 4],
+                            "values" : [{"kind" : 1, "idx" : 2}, {"kind" : 0, "idx" : 0}],
+                            "nums" : [1769472000],
                             "consts" : [ ]
                         },
-                        "max_prev" : 922337203685477, "max_vesting" : 922337203685477, "max_elapsed" : 922337203685477
+                        "max_prev" : 9223372036854771712,
+                        "max_vesting" : 9223372036854771712,
+                        "max_elapsed" : 9223372036854771712
                     }
                 },{
                     "scope": "gls.charge", "payer": "gls", "pk": 91600047785731,
@@ -467,7 +472,9 @@
                             "nums" : [353894400],
                             "consts" : [ ]
                         },
-                        "max_prev" : 922337203685477, "max_vesting" : 922337203685477, "max_elapsed" : 922337203685477
+                        "max_prev" : 9223372036854771712,
+                        "max_vesting" : 9223372036854771712,
+                        "max_elapsed" : 9223372036854771712
                     }
                 }
             ]

--- a/golos.publication/golos.publication.cpp
+++ b/golos.publication/golos.publication.cpp
@@ -992,6 +992,7 @@ void publication::set_limit(
     });
 }
 
+// TODO: move maxtokenprop to setparams #828
 void publication::set_rules(const funcparams& mainfunc, const funcparams& curationfunc, const funcparams& timepenalty,
     uint16_t maxtokenprop, eosio::symbol tokensymbol
 ) {

--- a/golos.publication/golos.publication.cpp
+++ b/golos.publication/golos.publication.cpp
@@ -57,8 +57,8 @@ extern "C" {
             execute_action(&publication::paymssgrwrd);
         if (NN(setmaxpayout) == action)
             execute_action(&publication::set_max_payout);
-        if (NN(deletevotes) == action) 
-            execute_action(&publication::deletevotes); 
+        if (NN(deletevotes) == action)
+            execute_action(&publication::deletevotes);
     }
 #undef NN
 }
@@ -166,11 +166,11 @@ void publication::create_message(
     }
 
     use_charge(
-            lims, 
-            parent_id.author ? structures::limitparams::COMM : structures::limitparams::POST, 
+            lims,
+            parent_id.author ? structures::limitparams::COMM : structures::limitparams::POST,
             issuer, message_id.author,
-            golos::vesting::get_account_effective_vesting(config::vesting_name, message_id.author, token_code).amount, 
-            token_code, 
+            golos::vesting::get_account_effective_vesting(config::vesting_name, message_id.author, token_code).amount,
+            token_code,
             vestpayment);
 
     tables::permlink_table permlink_table(_self, message_id.author.value);
@@ -349,13 +349,13 @@ void publication::pay_to(std::vector<eosio::token::recipient>&& arg, bool vestin
     }
     auto token_symbol = recipients.at(0).quantity.symbol;
     auto token_code = token_symbol.code();
-    
+
     std::vector<eosio::token::recipient> closed_vesting_payouts;
-    
+
     for (auto& recipient_obj : recipients) {
         eosio::check(token_symbol == recipient_obj.quantity.symbol, "publication::pay_to: different tokens in one payment");
         eosio::check(recipient_obj.quantity.amount > 0, "publication::pay_to: quantity.amount <= 0");
-        
+
         if (vesting_mode) {
             if (golos::vesting::balance_exist(config::vesting_name, recipient_obj.to, token_code)) {
                 recipient_obj.memo = config::send_prefix + recipient_obj.to.to_string() + "; " + recipient_obj.memo;
@@ -373,12 +373,12 @@ void publication::pay_to(std::vector<eosio::token::recipient>&& arg, bool vestin
             recipient_obj.to = _self;
         }
     }
-    
+
     if (vesting_mode) {
         recipients.erase(
-            std::remove_if(recipients.begin(), recipients.end(), [](const eosio::token::recipient& r) { return r.to == name(); }), 
-            recipients.end());    
-        
+            std::remove_if(recipients.begin(), recipients.end(), [](const eosio::token::recipient& r) { return r.to == name(); }),
+            recipients.end());
+
         if (!recipients.empty()) {
             INLINE_ACTION_SENDER(token, bulktransfer) (config::token_name, {_self, config::code_name}, {_self, recipients});
         }
@@ -393,11 +393,11 @@ void publication::pay_to(std::vector<eosio::token::recipient>&& arg, bool vestin
 
 std::pair<int64_t, bool> publication::fill_curator_payouts(
         std::vector<eosio::token::recipient>& payouts,
-        structures::mssgid message_id, 
-        uint64_t msgid, 
-        int64_t max_rewards, 
-        fixp_t weights_sum, 
-        symbol tokensymbol, 
+        structures::mssgid message_id,
+        uint64_t msgid,
+        int64_t max_rewards,
+        fixp_t weights_sum,
+        symbol tokensymbol,
         std::string memo)
 {
     tables::vote_table vs(_self, message_id.author.value);
@@ -426,7 +426,7 @@ std::pair<int64_t, bool> publication::fill_curator_payouts(
             }
             eosio::check(now_paid + v->paid_amount <= claim, "LOGIC ERROR! fill_curator_payouts: wrong paid amount");
             auto to_pay = claim - (now_paid + v->paid_amount);
-            
+
             if (payouts.size() < config::target_payments_per_trx || !to_pay) {
                 if (to_pay) {
                     payouts.push_back({v->voter, eosio::asset(to_pay, tokensymbol), memo});
@@ -484,10 +484,10 @@ int16_t publication::use_charge(tables::limit_table& lims, structures::limitpara
 }
 
 void publication::use_postbw_charge(
-        tables::limit_table& lims, 
-        name issuer, name account, 
-        symbol_code token_code, 
-        int64_t mssg_id) 
+        tables::limit_table& lims,
+        name issuer, name account,
+        symbol_code token_code,
+        int64_t mssg_id)
 {
     auto bw_lim_itr = lims.find(structures::limitparams::POSTBW);
     if(bw_lim_itr->price >= 0)
@@ -555,9 +555,9 @@ void publication::close_messages(name payer) {
         eosio::check(pool.state.msgs != 0, "LOGIC ERROR! publication::payrewards: pool.msgs is equal to zero");
         atmsp::machine<fixp_t> machine;
         fixp_t sharesfn = set_and_run(
-                machine, 
-                pool.rules.mainfunc.code, 
-                {FP(mssg_itr->state.netshares)}, 
+                machine,
+                pool.rules.mainfunc.code,
+                {FP(mssg_itr->state.netshares)},
                 {{fixp_t(0), FP(pool.rules.mainfunc.maxarg)}});
 
         asset mssg_reward;
@@ -606,7 +606,7 @@ void publication::close_messages(name payer) {
             state.rsharesfn = new_rsharesfn.data();
         }
 
-        mssg_reward = asset(payout, state.funds.symbol); 
+        mssg_reward = asset(payout, state.funds.symbol);
 
         message_index.modify(mssg_itr, eosio::same_payer, [&]( auto &item ) {
                 item.cashout_time = microseconds::maximum().count();
@@ -643,7 +643,7 @@ void publication::close_messages(name payer) {
 
 void publication::deletevotes(int64_t message_id, name author) {
     require_auth(_self);
-    
+
     tables::vote_table vote_table(_self, author.value);
     auto votetable_index = vote_table.get_index<"messageid"_n>();
     auto vote_itr = votetable_index.lower_bound(std::make_tuple(message_id, INT64_MAX));
@@ -651,7 +651,7 @@ void publication::deletevotes(int64_t message_id, name author) {
     for (auto vote_etr = votetable_index.end(); vote_itr != vote_etr;) {
         if (config::max_deletions_per_trx <= i++) {
             break;
-        } 
+        }
         auto& vote = *vote_itr;
         ++vote_itr;
         if (vote.message_id != message_id) {
@@ -660,7 +660,7 @@ void publication::deletevotes(int64_t message_id, name author) {
         }
         vote_table.erase(vote);
     }
-    
+
     if (vote_itr != votetable_index.end()) {
         send_deletevotes_trx(message_id, author);
     }
@@ -686,19 +686,19 @@ void publication::paymssgrwrd(structures::mssgid message_id) {
 
     eosio::check((curation_payout <= payout.amount) && (curation_payout >= 0),
             "publication::payrewards: wrong curation_payout");
-            
+
     std::vector<eosio::token::recipient> vesting_payouts;
     bool completed = false;
     int64_t paid = 0;
     std::tie(paid, completed) = fill_curator_payouts(
             vesting_payouts,
-            message_id, 
-            mssg_itr->id, 
-            curation_payout, 
-            FP(mssg_itr->state.sumcuratorsw), 
-            payout.symbol, 
+            message_id,
+            mssg_itr->id,
+            curation_payout,
+            FP(mssg_itr->state.sumcuratorsw),
+            payout.symbol,
             get_memo("curators", message_id));
-    
+
     auto max_add_payouts = mssg_itr->beneficiaries.size() + 2; //beneficiaries, author tokens and author vesting
     bool last_payment = completed && ((vesting_payouts.size() + max_add_payouts <= config::max_payments_per_trx) || vesting_payouts.empty());
 
@@ -706,20 +706,20 @@ void publication::paymssgrwrd(structures::mssgid message_id) {
         auto actual_curation_payout = paid + mssg_itr->paid_amount;
         auto unclaimed_rewards = curation_payout - actual_curation_payout;
         eosio::check(unclaimed_rewards >= 0, "publication::payrewards: unclaimed_rewards < 0");
-        
+
         payout.amount -= curation_payout;
-        
+
         int64_t ben_payout_sum = 0;
         for (auto& ben: mssg_itr->beneficiaries) {
             auto ben_payout = cyber::safe_pct(payout.amount, ben.weight);
-            eosio::check((0 <= ben_payout) && (ben_payout <= payout.amount - ben_payout_sum), 
+            eosio::check((0 <= ben_payout) && (ben_payout <= payout.amount - ben_payout_sum),
                     "LOGIC ERROR! publication::payrewards: wrong ben_payout value");
             if (ben_payout > 0) {
                 vesting_payouts.push_back({ben.account, eosio::asset(ben_payout, payout.symbol), get_memo("benefeciary", message_id)});
                 ben_payout_sum += ben_payout;
             }
         }
-        
+
         payout.amount -= ben_payout_sum;
         auto token_payout = cyber::safe_pct(mssg_itr->tokenprop, payout.amount);
         eosio::check(payout.amount >= token_payout, "publication::payrewards: wrong token_payout value");
@@ -862,9 +862,9 @@ void publication::set_vote(name voter, const structures::mssgid& message_id, int
     eosio::check(WP(pool->state.rsharesfn) >= 0, "pool state rsharesfn overflow");
 
     auto sumcuratorsw_delta = get_delta(
-            machine, 
-            FP(mssg_itr->state.voteshares), 
-            FP(msg_new_state.voteshares), 
+            machine,
+            FP(mssg_itr->state.voteshares),
+            FP(msg_new_state.voteshares),
             pool->rules.curationfunc);
     msg_new_state.sumcuratorsw = (FP(mssg_itr->state.sumcuratorsw) + sumcuratorsw_delta).data();
     message_table.modify(mssg_itr, eosio::same_payer, [&](auto &item) {
@@ -885,9 +885,9 @@ void publication::set_vote(name voter, const structures::mssgid& message_id, int
     elap_t curatorsw_factor =
         std::max(std::min(
         set_and_run(
-            machine, 
-            pool->rules.timepenalty.code, 
-            {fp_cast<fixp_t>(time_delta, false)}, 
+            machine,
+            pool->rules.timepenalty.code,
+            {fp_cast<fixp_t>(time_delta, false)},
             {{fixp_t(0), FP(pool->rules.timepenalty.maxarg)}}),
         fixp_t(1)), fixp_t(0));
 
@@ -921,9 +921,9 @@ void publication::set_vote(name voter, const structures::mssgid& message_id, int
 }
 
 void publication::fill_depleted_pool(
-        tables::reward_pools& pools, 
-        eosio::asset quantity, 
-        tables::reward_pools::const_iterator excluded) 
+        tables::reward_pools& pools,
+        eosio::asset quantity,
+        tables::reward_pools::const_iterator excluded)
 {
     using namespace tables;
     using namespace structures;
@@ -961,20 +961,20 @@ void publication::on_transfer(name from, name to, eosio::asset quantity, std::st
 }
 
 void publication::set_limit(
-        std::string act_str, 
-        symbol_code token_code, 
-        uint8_t charge_id, 
-        int64_t price, 
-        int64_t cutoff, 
-        int64_t vesting_price, 
-        int64_t min_vesting) 
+        std::string act_str,
+        symbol_code token_code,
+        uint8_t charge_id,
+        int64_t price,
+        int64_t cutoff,
+        int64_t vesting_price,
+        int64_t min_vesting)
 {
     using namespace tables;
     using namespace structures;
     require_auth(_self);
     eosio::check(
-            price < 0 || 
-            golos::charge::exist(config::charge_name, token_code, charge_id), 
+            price < 0 ||
+            golos::charge::exist(config::charge_name, token_code, charge_id),
             "publication::set_limit: charge doesn't exist");
     auto act = limitparams::act_from_str(act_str);
     eosio::check(act != limitparams::VOTE || charge_id == 0, "publication::set_limit: charge_id for VOTE should be 0");
@@ -1047,10 +1047,10 @@ void publication::send_poolerase_event(const structures::rewardpool& pool) {
 }
 
 void publication::send_poststate_event(
-        name author, 
-        const structures::permlink& permlink, 
-        const structures::message& post, 
-        fixp_t sharesfn) 
+        name author,
+        const structures::permlink& permlink,
+        const structures::message& post,
+        fixp_t sharesfn)
 {
     structures::post_event data{ author, permlink.value, post.state.netshares, post.state.voteshares,
         post.state.sumcuratorsw, sharesfn.data() };
@@ -1058,10 +1058,10 @@ void publication::send_poststate_event(
 }
 
 void publication::send_votestate_event(
-        name voter, 
-        const structures::voteinfo& vote, 
-        name author, 
-        const structures::permlink& permlink) 
+        name voter,
+        const structures::voteinfo& vote,
+        name author,
+        const structures::permlink& permlink)
 {
     structures::vote_event data{voter, author, permlink.value, vote.weight, vote.curatorsw, vote.rshares};
     eosio::event(_self, "votestate"_n, data).send();
@@ -1078,11 +1078,11 @@ void publication::send_postreward_event(const structures::mssgid& message_id, co
 }
 
 structures::funcinfo publication::load_func(
-        const funcparams& params, 
-        const std::string& name, 
-        const atmsp::parser<fixp_t>& pa, 
-        atmsp::machine<fixp_t>& machine, 
-        bool inc) 
+        const funcparams& params,
+        const std::string& name,
+        const atmsp::parser<fixp_t>& pa,
+        atmsp::machine<fixp_t>& machine,
+        bool inc)
 {
     eosio::check(params.maxarg > 0, "forum::load_func: params.maxarg <= 0");
     structures::funcinfo ret;
@@ -1094,10 +1094,10 @@ structures::funcinfo publication::load_func(
 }
 
 fixp_t publication::get_delta(
-        atmsp::machine<fixp_t>& machine, 
-        fixp_t old_val, 
-        fixp_t new_val, 
-        const structures::funcinfo& func) 
+        atmsp::machine<fixp_t>& machine,
+        fixp_t old_val,
+        fixp_t new_val,
+        const structures::funcinfo& func)
 {
     func.code.to_machine(machine);
     elap_t old_fn = machine.run({old_val}, {{fixp_t(0), FP(func.maxarg)}});

--- a/golos.publication/objects.hpp
+++ b/golos.publication/objects.hpp
@@ -126,8 +126,7 @@ struct rewardrules {
     funcinfo mainfunc;
     funcinfo curationfunc;
     funcinfo timepenalty;
-    uint16_t maxtokenprop;  // percent
-    //uint64_t cashout_time; //TODO:
+    uint16_t maxtokenprop;  // percent  // TODO: move to params #828
 };
 
 struct poolstate {

--- a/golos.vesting/golos.vesting.cpp
+++ b/golos.vesting/golos.vesting.cpp
@@ -367,7 +367,7 @@ bool vesting::process_withdraws(eosio::time_point now, symbol symbol, name payer
             fail || last_payment ? obj = idx.erase(obj) : ++obj
         ) {
             if (max_steps-- <= 0) {
-            	return true;
+                return true;
             }
 
             fail = obj->remaining_payments == 0 || obj->to_withdraw < obj->withdraw_rate;  // must not happen

--- a/golos.vesting/parameters.hpp
+++ b/golos.vesting/parameters.hpp
@@ -23,7 +23,7 @@ using vesting_withdraw_param = param_wrapper<vesting_withdraw,2>;
 
 
 struct vesting_min_amount : parameter {
-    uint64_t min_amount;
+    uint64_t min_amount;    // withdraw
 };
 using vesting_min_amount_param = param_wrapper<vesting_min_amount,1>;
 

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -9,5 +9,5 @@ CYBERWAY_PREFIX='_CYBERWAY_'
 from utils import fixp_max
 _2s = 2 * 2000000000000
 golos_curation_func_str = str(fixp_max) + " / ((" + str(_2s) + " / max(x, 0.1)) + 1)"
-#see https://github.com/GolosChain/golos/blob/master/libraries/chain/database.cpp: database::get_content_constant_s()
-#and ttps://github.com/GolosChain/golos/blob/master/libraries/chain/steem_evaluator.cpp: vote_evaluator::do_apply(...) 
+#see https://github.com/GolosChain/golos/blob/master/libraries/chain/database.cpp : database::get_content_constant_s()
+#and https://github.com/GolosChain/golos/blob/master/libraries/chain/steem_evaluator.cpp : vote_evaluator::do_apply(...)

--- a/scripts/golos-boot-sequence/golos-boot-sequence.py
+++ b/scripts/golos-boot-sequence/golos-boot-sequence.py
@@ -309,15 +309,15 @@ def createCommunity():
         retry(args.cleos + 'push action gls.emit setparams ' + jsonArg([
             [
                 ['inflation_rate',{
-                    'start':1500,
+                    'start':1515 - (29000000//250000),  # initial emission set related to current Golos block number
                     'stop':95,
                     'narrowing':250000
                 }],
                 ['reward_pools',{
                     'pools':[
                         {'name':'gls.ctrl','percent':0},
-                        {'name':'gls.publish','percent':6000},
-                        {'name':'gls.vesting','percent':2400}
+                        {'name':'gls.publish','percent':6667},
+                        {'name':'gls.vesting','percent':2667}
                     ]
                 }],
                 ['emit_token',{
@@ -332,16 +332,24 @@ def createCommunity():
             [
                 ['vesting_withdraw',{
                     'intervals':13,
-                    'interval_seconds':120
+                    'interval_seconds':7*24*3600
                 }],
                 ['vesting_amount',{
-                    'min_amount':10000
+                    'min_amount':3 * 10 * 3500 * 1000000    # min withdraw is 10x account creation fee
                 }],
                 ['vesting_delegation',{
-                    'min_amount':5000000,
-                    'min_remainder':15000000,
+                    'min_amount':   3500*1000000,   # min_update = create_account_min_golos_fee
+                    'min_remainder':3500*1000000,   # min_delegation (in GESTS: 1 GOLOS ≈ 3500 GESTS)
+                    # the following values are actual median, but they are useless
+                    # 'min_amount':   int(0.030*3500*1000000),    # min_update = create_account_min_golos_fee
+                    # 'min_remainder':int(0.010*3500*1000000),    # min_delegation (in GESTS: 1 GOLOS ≈ 3500 GESTS)
                     'min_time':0,
-                    'return_time':120
+                    'return_time':7*24*3600,
+                    'max_delegators':32
+                }],
+                ['bwprovider',{
+                    'actor':'gls',
+                    'permission':'providebw'
                 }]
             ]]) + '-p gls')
         retry(args.cleos + 'push action gls.ctrl setparams ' + jsonArg([
@@ -353,7 +361,7 @@ def createCommunity():
                     'name':'gls'
                 }],
                 ['max_witnesses',{
-                    'max':5
+                    'max':21
                 }],
                 ['multisig_perms',{
                     'super_majority':0,
@@ -386,19 +394,23 @@ def createWitnessAccounts():
 def initCommunity():
     if not args.golos_genesis:
         retry(args.cleos + 'push action gls.publish setparams ' + jsonArg([[
-            ['st_max_vote_changes', {'value':5}],
-            ['st_cashout_window', {'window': 120, 'upvote_lockout': 15}],
+            ['st_max_vote_changes', {'value': 5}],
+            ['st_cashout_window', {'window': 7*24*3600, 'upvote_lockout': 60}],
             ['st_max_beneficiaries', {'value': 64}],
             ['st_max_comment_depth', {'value': 127}],
             ['st_social_acc', {'value': 'gls.social'}],
             ['st_referral_acc', {'value': ''}], # TODO Add referral contract to posting-settings
-            ['st_curators_prcnt', {'min_curators_prcnt': 0, 'max_curators_prcnt': 9000}]
+            ['st_curators_prcnt', {'min_curators_prcnt': 5000, 'max_curators_prcnt': 10000}]
         ]]) + '-p gls.publish')
-    
+
         retry(args.cleos + 'push action gls.publish setrules ' + jsonArg({
             "mainfunc":{"str":"x","maxarg":fixp_max},
-            "curationfunc":{"str":golos_curation_func_str,"maxarg":fixp_max},
-            "timepenalty":{"str":"x/1800","maxarg":1800},
+            # "curationfunc":{"str":golos_curation_func_str,"maxarg":fixp_max}, # bounded
+            "curationfunc":{"str":"x","maxarg":fixp_max},
+            # without auction:
+            "timepenalty":{"str":"1","maxarg":1<<12},
+            # 30 minutes auction:
+            #"timepenalty":{"str":"x/1800","maxarg":1800},
             "maxtokenprop":5000,
             "tokensymbol":args.token
         }) + '-p gls.publish')

--- a/tests/golos.charge_test_api.hpp
+++ b/tests/golos.charge_test_api.hpp
@@ -11,7 +11,7 @@ struct golos_charge_api: base_contract_api {
     void initialize_contract() {
         _tester->install_contract(_code, contracts::charge_wasm(), contracts::charge_abi());
     }
-    
+
     action_result set_restorer(name issuer, uint8_t charge_id, std::string func_str,
         int64_t max_prev, int64_t max_vesting, int64_t max_elapsed) {
         return push(N(setrestorer), issuer, args()
@@ -39,7 +39,7 @@ struct golos_charge_api: base_contract_api {
             ("vesting_price", vesting_price)
         );
     }
-    
+
     action_result use_and_store(name issuer, name user, uint8_t charge_id, int64_t stamp_id, int64_t price) {
         return push(N(useandstore), issuer, args()
             ("user", user)
@@ -49,7 +49,7 @@ struct golos_charge_api: base_contract_api {
             ("price", price)
         );
     }
-    
+
     action_result remove_stored(name issuer, name user, uint8_t charge_id, int64_t stamp_id) {
         return push(N(removestored), issuer, args()
             ("user", user)

--- a/tests/golos.publication_rewards_tests.cpp
+++ b/tests/golos.publication_rewards_tests.cpp
@@ -377,9 +377,9 @@ public:
 
     void pay(
             account_name from,
-            account_name to, 
+            account_name to,
             double payout,
-            payment_t mode) 
+            payment_t mode)
     {
         if (mode == payment_t::TOKEN) {
             if (!_state.balances[to].tokenclosed)
@@ -465,7 +465,7 @@ public:
                     author_payout -= ben_payout_sum;
 
                     auto author_token_rwrd = author_payout * m.tokenprop;
-                    pay(_forum_name, m.key.author, author_token_rwrd, payment_t::TOKEN); 
+                    pay(_forum_name, m.key.author, author_token_rwrd, payment_t::TOKEN);
                     pay(_forum_name, m.key.author, author_payout - author_token_rwrd, payment_t::VESTING);
 
                     p.messages.erase(itr_m++);
@@ -569,8 +569,6 @@ public:
                 ? post.upvote(voter, message_id, weight)
                 : post.downvote(voter, message_id, -weight);
 
-//        message_key msg_key{author, permlink};
-
         string ret_str = ret;
         const auto current_time = control->head_block_time().sec_since_epoch();
         if ((ret == success()) || (ret_str.find("forum::apply_limits:") != string::npos)) {
@@ -614,7 +612,7 @@ public:
             _state.balances[owner].tokenclosed = true;
         return ret;
     }
-    
+
     action_result close_vest_acc(name owner, symbol symbol) {
         auto ret = vest.close(owner, symbol);
         if (ret == success())
@@ -638,7 +636,7 @@ public:
                 interest_rate,
                 quantity.to_real()
             });
-            _state.dlg_balances[from].delegated += quantity.to_real(); 
+            _state.dlg_balances[from].delegated += quantity.to_real();
             _state.dlg_balances[to].received += quantity.to_real();
         }
         return ret;
@@ -964,7 +962,7 @@ BOOST_FIXTURE_TEST_CASE(golos_curation_test, reward_calcs_tester) try {
     BOOST_TEST_MESSAGE("golos_curation_test");
     int64_t maxfp = std::numeric_limits<fixp_t>::max();
     auto bignum = 500000000000;
-    
+
     vector<account_name> additional_users;
     auto add_users_num = 210 - _users.size();
     for (size_t u = 0; u < add_users_num; u++) {
@@ -972,7 +970,7 @@ BOOST_FIXTURE_TEST_CASE(golos_curation_test, reward_calcs_tester) try {
     }
     create_accounts(additional_users);
     _users.insert(_users.end(), additional_users.begin(), additional_users.end());
-    
+
     init(bignum, 500000);
     produce_blocks();
     BOOST_TEST_MESSAGE("--- setrules");
@@ -1041,7 +1039,7 @@ BOOST_FIXTURE_TEST_CASE(close_token_acc_test, reward_calcs_tester) try {
     produce_blocks(golos::seconds_to_blocks(post.window));
     BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
-    BOOST_CHECK_GT(token.get_account(_forum_name)["payments"].as<asset>(), forum_name_balance); 
+    BOOST_CHECK_GT(token.get_account(_forum_name)["payments"].as<asset>(), forum_name_balance);
     check();
 } FC_LOG_AND_RETHROW()
 
@@ -1080,7 +1078,7 @@ BOOST_FIXTURE_TEST_CASE(close_vest_acc_test, reward_calcs_tester) try {
     produce_blocks(golos::seconds_to_blocks(post.window));
     BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
-    BOOST_CHECK_GT(token.get_account(_forum_name)["payments"].as<asset>(), forum_name_balance); 
+    BOOST_CHECK_GT(token.get_account(_forum_name)["payments"].as<asset>(), forum_name_balance);
     check();
 } FC_LOG_AND_RETHROW()
 
@@ -1122,7 +1120,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     const auto amount = vest.make_asset(min_remainder);
     auto vest_amount = vest.make_asset(150000000);
     uint16_t interest_rate = 3000;
-    
+
     BOOST_TEST_MESSAGE("--- one delegator interest_rate > 0");
     BOOST_TEST_MESSAGE("--- create_message: " << name{_users[0]}.to_string());
     BOOST_CHECK_EQUAL(success(), create_message({_users[0], "permlink"}));
@@ -1184,7 +1182,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     BOOST_CHECK_GT(vest.get_balance_raw(_users[20])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_EQUAL(vest.get_balance_raw(_users[4])["vesting"].as<asset>(), delegator_amount);
     check();
-    
+
     BOOST_TEST_MESSAGE("--- add_funds_to_forum");
     BOOST_CHECK_EQUAL(success(), add_funds_to_forum(50000));
     check();
@@ -1245,7 +1243,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     BOOST_TEST_MESSAGE("--- add_funds_to_forum");
     BOOST_CHECK_EQUAL(success(), add_funds_to_forum(50000));
     check();
-    
+
     BOOST_TEST_MESSAGE("--- checking that interest_rate < 1");
     BOOST_TEST_MESSAGE("--- create_message: " << name{_users[0]}.to_string());
     BOOST_CHECK_EQUAL(success(), create_message({_users[0], "permlink5"}));
@@ -1300,7 +1298,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
 
     BOOST_TEST_MESSAGE("--- increase vesting amount for " << name{_users[15]}.to_string());
     add_vesting({_users[15]}, vest_amount.get_amount());
-    
+
     BOOST_TEST_MESSAGE("--- checking that interest_rate doesn't overflow and curator has no reward");
     BOOST_TEST_MESSAGE("--- create_message: " << name{_users[0]}.to_string());
     BOOST_CHECK_EQUAL(success(), create_message({_users[0], "permlink6"}));
@@ -1320,7 +1318,7 @@ BOOST_FIXTURE_TEST_CASE(golos_delegators_test, reward_calcs_tester) try {
     produce_blocks(golos::seconds_to_blocks(post.window));
     BOOST_CHECK_EQUAL(success(), post.closemssgs());
     produce_block();
-    
+
     BOOST_CHECK_EQUAL(voter_amount.get_amount(), 0);
     BOOST_CHECK_EQUAL(vest.get_balance_raw(_users[24])["vesting"].as<asset>(), voter_amount);
     BOOST_CHECK_GT(vest.get_balance_raw(_users[15])["vesting"].as<asset>(), delegator_amount);
@@ -1332,7 +1330,7 @@ BOOST_FIXTURE_TEST_CASE(a_lot_of_delegators_test, reward_calcs_tester) try {
     BOOST_TEST_MESSAGE("a_lot_of_delegators_test");
     int64_t maxfp = std::numeric_limits<fixp_t>::max();
     auto bignum = 500000000000;
-    
+
     vector<account_name> additional_users;
     size_t voters_num = 30;
     auto total_users_num = 210;
@@ -1356,7 +1354,7 @@ BOOST_FIXTURE_TEST_CASE(a_lot_of_delegators_test, reward_calcs_tester) try {
 
     BOOST_TEST_MESSAGE("--- add_funds_to_forum");
     BOOST_CHECK_EQUAL(success(), add_funds_to_forum(50000));
-    
+
     for (size_t i = voters_num; i < total_users_num; i++) {
         produce_block();
         BOOST_CHECK_EQUAL(success(), delegate_vest(_users[i], _users[i % voters_num], asset(vest_amount, vest._symbol), cfg::_100percent));
@@ -1386,7 +1384,7 @@ BOOST_FIXTURE_TEST_CASE(posting_bw_penalty, reward_calcs_tester) try {
     auto reward_weight_delta = 0.001;
     init(bignum, 500000);
     produce_blocks();
-    
+
     auto params = "[" + post.get_str_cashout_window(window, post.upvote_lockout) + "]";
     BOOST_CHECK_EQUAL(success(), post.set_params(params));
 
@@ -1395,15 +1393,15 @@ BOOST_FIXTURE_TEST_CASE(posting_bw_penalty, reward_calcs_tester) try {
     limitsarg lims = {{"t/300", "t/200", "t/(5*86400)", "t*p/86400"}, {{1, 0, cfg::_100percent, cfg::_100percent}, {2, 1, cfg::_100percent, cfg::_100percent/10}, {0, 2, cfg::_100percent, cfg::_100percent/(5*40)}, {3, 3, pb_cutoff, cfg::_100percent}}, {0, 0}, {0, 0, 0}};
     vector<limits::func_t> restorers_fn = {
             [](double p, double v, double t){ return t/300; },
-            [](double p, double v, double t){ return t/200; }, 
+            [](double p, double v, double t){ return t/200; },
             [](double p, double v, double t){ return t/(5*86400); },
             [](double p, double v, double t){ return t*p/86400; }
         };
-    
+
     BOOST_CHECK_EQUAL(success(), setrules({"x", maxfp}, {golos_curation::func_str, maxfp}, {"x/1800", 1800},
         [](double x){ return x; }, golos_curation::func, [](double x){ return x / 1800.0; }, lims, std::move(restorers_fn)));
     check();
-    
+
     BOOST_TEST_MESSAGE("--- create messages");
     auto charge = 0.0;
     auto charge_prev = 0.0;


### PR DESCRIPTION
Notes:
1. curation percents are not stable, should be re-checked at transit time
2. emission `infrate.start` set to block **29000000**, should be corrected at transit time
3. delegation `min_amount` (derived from `create_account_min_golos_fee` Golos chain parameter) and `min_remainder` (derived from `min_delegation`) values increased to ≈1 GOLOS token and converter to GOLOS vesting (price 1:3500 used). Current Golos values are useless
4. withdraw `min_amount` is equal to `account_creation_fee`×10 for **all accounts**: miners "discount" not supported
5. curation function set to linear, time penalty (auction) removed
***
2nd commit is refactoring only (*maybe some day we all setup IDEs to auto-remove trailing spaces ; )*)