### PR TITLE
Fix voting battery price #829

### DIFF
--- a/golos.vesting/golos.vesting.cpp
+++ b/golos.vesting/golos.vesting.cpp
@@ -52,11 +52,14 @@ void vesting::setparams(symbol symbol, std::vector<vesting_param> params) {
     }
 }
 
+// memo can contain real recipient if formatted like "send to: RECIPIENT; comment" (';' and comment part are optional)
 name get_recipient(const std::string& memo) {
     size_t memo_size = memo.size();
-    const auto find_symbol = memo.find(';');
-    if (find_symbol != std::string::npos && memo.size())
-        memo_size = find_symbol;
+    if (memo_size) {
+        const auto find_symbol = memo.find(';');
+        if (find_symbol != std::string::npos)
+            memo_size = find_symbol;
+    }
 
     const size_t pref_size = config::send_prefix.size();
     if (memo_size < pref_size || memo.substr(0, pref_size) != config::send_prefix)

--- a/tests/cyber.token_test_api.hpp
+++ b/tests/cyber.token_test_api.hpp
@@ -40,7 +40,7 @@ struct cyber_token_api: base_contract_api {
         );
     }
 
-    action_result issue(account_name issuer, account_name to, asset quantity, string memo) {
+    action_result issue(account_name issuer, account_name to, asset quantity, string memo = "") {
         return push(N(issue), issuer, args()
             ("to", to)
             ("quantity", quantity)
@@ -48,6 +48,9 @@ struct cyber_token_api: base_contract_api {
         );
     }
 
+    action_result open(name owner) {
+        return open(owner, _symbol, owner);
+    }
     action_result open(account_name owner, symbol symbol, account_name payer = {}) {
         return push(N(open), owner, args()
             ("owner", owner)

--- a/tests/golos.params_tests.cpp
+++ b/tests/golos.params_tests.cpp
@@ -101,7 +101,7 @@ public:
     void prepare_balances() {
         token.create_invoice_authority(BLOG, {cfg::emission_name});
         BOOST_CHECK_EQUAL(success(), token.create(BLOG, dasset(100500)));
-        BOOST_CHECK_EQUAL(success(), vest.create_vesting(BLOG, _token));
+        BOOST_CHECK_EQUAL(success(), vest.create_vesting(BLOG));
         BOOST_CHECK_EQUAL(success(), vest.open(cfg::vesting_name, _token, cfg::vesting_name));
         vector<std::pair<uint64_t,double>> amounts = {
             {_alice, 800}, {_bob, 700},

--- a/tests/golos.posting_test_api.hpp
+++ b/tests/golos.posting_test_api.hpp
@@ -138,14 +138,14 @@ struct golos_posting_api: base_contract_api {
         );
     }
 
-    action_result upvote(account_name voter, mssgid message_id, uint16_t weight) {
+    action_result upvote(account_name voter, mssgid message_id, uint16_t weight = cfg::_100percent) {
         return push(N(upvote), voter, args()
             ("voter", voter)
             ("message_id", message_id)
             ("weight", weight)
         );
     }
-    action_result downvote(account_name voter, mssgid message_id, uint16_t weight) {
+    action_result downvote(account_name voter, mssgid message_id, uint16_t weight = cfg::_100percent) {
         return push(N(downvote), voter, args()
             ("voter", voter)
             ("message_id", message_id)
@@ -260,8 +260,9 @@ struct golos_posting_api: base_contract_api {
         return variant();
     }
 
-    variant get_vote(account_name acc, uint64_t id) {
-        return _tester->get_chaindb_struct(_code, acc, N(vote), id, "voteinfo");
+    // Note: vote scope is message author, not voter
+    variant get_vote(account_name author, uint64_t id) {
+        return _tester->get_chaindb_struct(_code, author, N(vote), id, "voteinfo");
     }
 
     std::vector<variant> get_reward_pools() {

--- a/tests/golos.posting_unit_tests.cpp
+++ b/tests/golos.posting_unit_tests.cpp
@@ -1,0 +1,224 @@
+/*
+ * Pure unit-tests, not relying on rewards simulation model
+ */
+
+#include "golos_tester.hpp"
+#include "golos.posting_test_api.hpp"
+#include "golos.vesting_test_api.hpp"
+#include "golos.charge_test_api.hpp"
+#include "cyber.token_test_api.hpp"
+#include "../golos.publication/types.h"
+#include "../golos.publication/config.hpp"
+#include "contracts.hpp"
+
+namespace cfg = golos::config;
+using namespace fixed_point_utils;
+using namespace eosio::testing;
+
+#define PRECISION 3
+#define TOKEN_NAME "GOLOS"
+constexpr auto MAX_FIXP = std::numeric_limits<fixp_t>::max();
+
+constexpr uint16_t max_token_percent = 5000;
+constexpr auto votes_restore_per_day = 40;
+constexpr auto days_to_restore_votes = 5;
+constexpr auto hour_seconds = 60*60;
+constexpr auto day_seconds = hour_seconds * 24;
+constexpr auto week_seconds = day_seconds * 7;
+
+constexpr auto posts_window = 5*60, posts_per_window = 1;
+constexpr auto comments_window = 200, comments_per_window = 10;
+
+class posting_tester : public golos_tester {
+protected:
+    symbol _token_symbol;
+    golos_posting_api post;
+    golos_vesting_api vest;
+    golos_charge_api charge;
+    cyber_token_api token;
+
+    account_name _forum_name;
+    account_name _issuer;
+    vector<account_name> _users;
+
+    struct errors: contract_error_messages {
+    } err;
+
+public:
+    posting_tester()
+        : golos_tester(cfg::publish_name)
+        , _token_symbol(PRECISION, TOKEN_NAME)
+        , post({this, _code, _token_symbol})
+        , vest({this, cfg::vesting_name, _token_symbol})
+        , charge({this, cfg::charge_name, _token_symbol})
+        , token({this, cfg::token_name, _token_symbol})
+
+        , _issuer(N(issuer))
+        , _users{N(alice), N(bob), N(carol), N(user), N(u1), N(u2), N(u3), N(u4), N(u5)} {
+
+        create_accounts({_code, _issuer, cfg::token_name, cfg::vesting_name, cfg::control_name, cfg::charge_name});
+        create_accounts(_users);
+        produce_block();
+        install_contract(cfg::token_name, contracts::token_wasm(), contracts::token_abi());
+        vest.add_changevest_auth_to_issuer(_issuer, cfg::control_name);
+        vest.initialize_contract(cfg::token_name);
+        charge.initialize_contract();
+        post.initialize_contract(cfg::token_name, cfg::charge_name);
+
+        set_authority(_issuer, cfg::invoice_name, create_code_authority({charge._code, post._code}), "active");
+        link_authority(_issuer, charge._code, cfg::invoice_name, N(use));
+        link_authority(_issuer, charge._code, cfg::invoice_name, N(usenotifygt));
+        link_authority(_issuer, vest._code, cfg::invoice_name, N(retire));
+    }
+
+    void init(double total_funds) {
+        auto funds = token.make_asset(total_funds);
+        BOOST_CHECK_EQUAL(success(), post.init_default_params());
+        BOOST_CHECK_EQUAL(success(), token.create(_issuer, funds));
+        BOOST_CHECK_EQUAL(success(), token.issue(_issuer, _issuer, funds));
+        BOOST_CHECK_EQUAL(success(), token.open(_code));
+        BOOST_CHECK_EQUAL(success(), vest.create_vesting(_issuer));
+        BOOST_CHECK_EQUAL(success(), vest.open(_code));
+    }
+
+    void buy_vesting_for_users(std::vector<account_name> users, int64_t funds) {
+        asset amount{funds, _token_symbol};
+        for (const auto& u : users) {
+            if (vest.get_balance_raw(u).is_null()) {
+                BOOST_CHECK_EQUAL(success(), vest.open(u));
+            }
+            BOOST_CHECK_EQUAL(success(), token.transfer(_issuer, cfg::vesting_name, amount, "send to: " + string(u)));
+        }
+    }
+
+    void set_rules(
+        const funcparams& mainfn,
+        const funcparams& curationfn,
+        const funcparams& auctionfn,
+        limitsarg lims
+    ) {
+        static const std::vector<std::string> act_names{"post", "comment", "vote", "post bandwidth"};
+        static const int64_t max_arg = static_cast<int64_t>(MAX_FIXP);
+
+        BOOST_CHECK_EQUAL(act_names.size(), lims.limitedacts.size());
+        for (size_t i = 0; i < act_names.size(); i++) {
+            auto act = lims.limitedacts[i];
+            BOOST_CHECK_EQUAL(success(), charge.set_restorer(_issuer, act.chargenum,
+                lims.restorers[act.restorernum], max_arg, max_arg, max_arg));
+            BOOST_CHECK_EQUAL(success(), post.set_limit(
+                act_names[i],
+                act.chargenum,
+                act.chargeprice,
+                act.cutoffval,
+                lims.vestingprices.size() > i ? lims.vestingprices[i] : 0,
+                lims.minvestings.size() > i ? lims.minvestings[i] : 0
+            ));
+        }
+        BOOST_CHECK_EQUAL(success(), post.set_rules(mainfn, curationfn, auctionfn, max_token_percent));
+    }
+
+    enum class fn_preset {
+        base,
+        linear,
+        bounded
+    };
+    enum class lim_preset {
+        base,
+        real
+    };
+
+    void set_rules_with_preset(fn_preset fn, lim_preset lim = lim_preset::base) {
+        const limitsarg lim_base = {{"0"}, {{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {}, {}};
+        const limitsarg lim_real = {
+            {
+                "t/" + std::to_string(posts_window),
+                "t/" + std::to_string(comments_window),
+                "t/" + std::to_string(day_seconds * days_to_restore_votes),
+                "t*p/" + std::to_string(day_seconds)
+            }, {
+                {1, 0, cfg::_100percent, cfg::_100percent / posts_per_window},
+                {2, 1, cfg::_100percent, cfg::_100percent / comments_per_window},
+                {0, 2, cfg::_100percent, cfg::_100percent / (votes_restore_per_day * days_to_restore_votes)},
+                {3, 3, cfg::_100percent*4, cfg::_100percent}
+            },
+            {},
+            {}
+        };
+        const funcparams fn_linear[3] = {
+            {"x", MAX_FIXP},
+            {"x", MAX_FIXP},
+            {"1", FP(1 << fixed_point_fractional_digits)},
+        };
+        BOOST_CHECK(fn == fn_preset::linear); // Only linear function preset supported for now
+        BOOST_CHECK(lim == lim_preset::base || lim == lim_preset::real); // Unsupported limits preset
+        const auto& fns = fn_linear;
+        set_rules(fns[0], fns[1], fns[2], lim == lim_preset::base ? lim_base : lim_real);
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(posting_unit_tests)
+
+BOOST_FIXTURE_TEST_CASE(golos_rshares_test, posting_tester) try {
+    BOOST_TEST_MESSAGE("Test raw rshares and vote weights when use Golos-setup");
+    BOOST_TEST_MESSAGE("--- create test accounts and set predefined vesting values");
+    _users.resize(3);
+    const int64_t total_vests = 31061610388087ll;         // raw GESTS values obtained from sample Golos acc
+    const int64_t delegated = 30713649230251ll;
+    const int64_t effective = total_vests - delegated;
+    auto vests = effective;
+    init((vests / 1000 + 1) * _users.size());
+    produce_block();
+
+    auto poster = _users[0];
+    auto voter = _users[1];
+    auto hater = _users[2];
+    buy_vesting_for_users(_users, vests);
+    produce_block();
+
+    BOOST_CHECK_EQUAL(vest.get_balance_raw(voter)["vesting"]["_amount"], effective);
+    BOOST_CHECK_EQUAL(vest.get_balance_raw(hater)["vesting"]["_amount"], effective);
+
+    BOOST_TEST_MESSAGE("--- setrules");
+    set_rules_with_preset(fn_preset::linear, lim_preset::real);
+    produce_block();
+
+    auto votes_capacity = days_to_restore_votes * votes_restore_per_day;    // 200 by default
+    auto factor = cfg::_100percent / votes_capacity;                        // 50 by default
+    int n_comments = votes_capacity / factor;   // number of votes required to reduce factor
+    BOOST_TEST_MESSAGE("--- create_message and " + std::to_string(n_comments) + " comments");
+    mssgid post_id{poster, "post"};
+    BOOST_CHECK_EQUAL(success(), post.create_msg(post_id));
+    for (int i = 1; i <= n_comments; i++) {
+        BOOST_CHECK_EQUAL(success(), post.create_msg({poster, "comment" + std::to_string(i)}, post_id));
+    }
+    produce_block();
+
+    BOOST_TEST_MESSAGE("--- vote with 100%");
+    BOOST_CHECK_EQUAL(success(), post.upvote(voter, post_id));
+    produce_block();
+    BOOST_TEST_MESSAGE("--- flag with 100%");
+    BOOST_CHECK_EQUAL(success(), post.downvote(hater, post_id));
+    produce_block();
+
+    auto make_rshares = [](auto rshares, auto weight) {
+        return mvo("rshares", rshares)("curatorsw", weight);
+    };
+
+    int64_t expect = effective * factor / cfg::_100percent; // full weight vote
+    BOOST_CHECK_EQUAL(1739'805'789, expect);            // ensure it's same as tested manually (remove if change params)
+    CHECK_MATCHING_OBJECT(post.get_vote(poster, 0), make_rshares(expect, expect));
+    CHECK_MATCHING_OBJECT(post.get_vote(poster, 1), make_rshares(-expect, 0));
+
+    BOOST_TEST_MESSAGE("--- vote for comments and check reduced charge at the last vote");
+    for (int i = 1; i < n_comments; i++) {
+        BOOST_CHECK_EQUAL(success(), post.upvote(voter, {poster, "comment" + std::to_string(i)}));
+        produce_block();
+        CHECK_MATCHING_OBJECT(post.get_vote(poster, i+1), make_rshares(expect, expect));
+    }
+    BOOST_CHECK_EQUAL(success(), post.upvote(voter, {poster, "comment" + std::to_string(n_comments)}));
+    expect = effective * (factor-1) / cfg::_100percent;     // four votes reduce weight factor to 49
+    BOOST_CHECK_EQUAL(1705'009'673, expect);
+    CHECK_MATCHING_OBJECT(post.get_vote(poster, n_comments+1), make_rshares(expect, expect));
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/golos.vesting_test_api.hpp
+++ b/tests/golos.vesting_test_api.hpp
@@ -31,7 +31,7 @@ struct golos_vesting_api: base_contract_api {
     action_result create_vesting(name creator) {
         return create_vesting(creator, _symbol, golos::config::control_name);
     }
-    action_result create_vesting(name creator, symbol vesting_symbol, name notify_acc = N(notify.acc), bool skip_authority_check = false) {
+    action_result create_vesting(name creator, symbol vesting_symbol, name notify_acc, bool skip_authority_check = false) {
         if (!skip_authority_check) {
             BOOST_CHECK(_tester->has_code_authority(creator, cfg::changevest_name, _code));
             BOOST_CHECK(_tester->has_link_authority(creator, cfg::changevest_name, notify_acc, N(changevest)));


### PR DESCRIPTION
* fixes voting battery consumption
* adds rshares test to ensure given GESTS produce expected rshares and curator's weight (same as in Golos) (test added to both reward_calc and pure unit tests)
* disables limits_test #831
* adds new `posting_unit_tests.cpp` to contain pure unit tests which not depend on reward-calc model
* add some helpers to tests_api